### PR TITLE
ci/renovate: update pinned alpine packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,5 +59,33 @@
         "RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:(?<currentValue>\\S+)"
       ]
     },
-  ]
+    {
+      // Update pinned alpine packages in Dockerfile.
+      "customType": "regex",
+      "fileMatch": [ "Dockerfile" ],
+      "matchStrings": [
+        // Lines that loosely look like "apk add --repository community something=version".
+        // To keep this regex simple, only one package per "apk add" is supported.
+        "\\bapk\\b.+?\\badd\\b.+?(--repository|-X)[ =\\t]+(?<alpineRepo>[a-z]+)\\s+(?<depName>[-\\w]+?)=(?<currentValue>[-.\\w]+)"
+      ],
+      "versioningTemplate": "loose", // The most lenient versioning renovate supports.
+      // We use two different datasources for main and community, as alpine serves them in different URLs.
+      "datasourceTemplate": "custom.alpine-{{alpineRepo}}",
+      // Extracted "versions" include the package name, so here we strip that prefix using a regex.
+      "extractVersionTemplate": "{{depName}}-(?<version>.+).apk",
+    },
+  ],
+
+  "customDatasources": {
+    // Use alpine HTML mirror page as a repository. When using `html` format, renovate produces version strings from
+    // all links present in the page. The version is extracted from that using extractVersionTemplate above.
+    "alpine-main": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main/x86_64/",
+      "format": "html",
+    },
+    "alpine-community": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/",
+      "format": "html",
+    },
+  },
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,11 @@ FROM alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367eff
 
 RUN adduser --home / --uid 6666 --shell /bin/nologin --disabled-password k6
 
-# Tini reaps leftover processes.
-RUN apk --no-cache add tini
-# Last known working: 126.0.6478.126-r0
-# Current at the time of writing this: 126.0.6478.182-r0
-RUN apk --no-cache add chromium-swiftshader
+# Renovate updates the pinned packages below.
+# The --repository arg is required for renovate to know which alpine repo it should look for updates in.
+# To keep the renovate regex simple, only keep one package installation per line.
+RUN apk --no-cache add --repository community tini=0.19.0-r3 && \
+  apk --no-cache add --repository community chromium-swiftshader=128.0.6613.119-r0
 
 # As we rely on file capabilities, we cannot set `allowPrivilegeEscalation: false` in k8s. As a workaround, and to lower
 # potential attack surface, we get rid of any file that has the setuid bit set, such as


### PR DESCRIPTION
This adds a regex manager and a custom datasource so renovate can update pinned alpine packages.

Proof of concept (and proof of work) was done in https://github.com/roobre/renovate-alpine/pull/5