### PR TITLE
crocochrome: log chromium process state on unexpected exit

### DIFF
--- a/crocochrome.go
+++ b/crocochrome.go
@@ -149,6 +149,16 @@ func (s *Supervisor) Session() (SessionInfo, error) {
 			logger.Error("running chromium", "err", err)
 			logger.Error("chromium output", "stdout", stdout.String())
 			logger.Error("chromium output", "stderr", stderr.String())
+
+			if ps := cmd.ProcessState; ps != nil {
+				logger.Debug(
+					"chromium process finished",
+					"state", ps.String(),
+					"exitCode", ps.ExitCode(),
+					"rss", ps.SysUsage().(*syscall.Rusage).Maxrss,
+				)
+			}
+
 			return
 		}
 


### PR DESCRIPTION
Can be useful for troubleshooting if chromium has been killed by the OS, or exit by itself.

This will not be logged when chromium is killed due to context cancellation.