### PR TITLE
renovate: use "enabled" instead of `true` for platformCommit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,14 +5,13 @@
     ":semanticCommitsDisabled"
   ],
 
-
   "branchPrefix": "grafanarenovatebot/",
   // Used when renovate runs as a github app.
   // https://docs.renovatebot.com/configuration-options/#platformcommit
-  // Setting platformCommit to `true`, as required by Grafana policy, seems to make renovate think all PRs are modified,
+  // Setting platformCommit to "enabled", as required by Grafana policy, seems to make renovate think all PRs are modified,
   // as the dynamic author configured by github does not match the author set in `gitAuthor`. It is recommended to
   // leave it unset: https://github.com/renovatebot/renovate/discussions/29106.
-  "platformCommit": true,
+  "platformCommit": "enabled",
   "dependencyDashboard": false,
   "forkProcessing": "disabled",
 


### PR DESCRIPTION
`true` fails validation with the latest renovate versions.