### PR TITLE
ci: configure renovate to update itself

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,6 +44,20 @@
       "matchStrings": [
         "ghcr.io/grafana/grafana-build-tools:(?<currentValue>\\S+)"
       ]
-    }
+    },
+    {
+      // Update renovate version in renovate workflows (renovate itself and renovate config validation).
+      "customType": "regex",
+      "depNameTemplate": "ghcr.io/renovatebot/renovate",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker",
+      "fileMatch": [
+        "^\\.github/workflows/.*\\.ya?ml$",
+      ],
+      "matchStrings": [
+        "renovate-version: (?<currentValue>\\S+)",
+        "RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:(?<currentValue>\\S+)"
+      ]
+    },
   ]
 }

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -10,5 +10,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - run: |-
-          docker run -i --rm -v $(realpath .):/repo -w /repo --entrypoint renovate-config-validator ghcr.io/renovatebot/renovate --strict
+      - name: Validate renovate config
+        run: |-
+          # Renovate updates the line below. Please keep its formatting as it is.
+          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:38.67.1
+          docker run -i --rm -v $(realpath .):/repo -w /repo --entrypoint renovate-config-validator "$RENOVATE_IMAGE" --strict

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -22,7 +22,8 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@dd4d265eb8646cd04fc5f86ff8bc8d496d75a251 # v40.2.8
         with:
-          renovate-version: 37.420.1@sha256:528f003c9aa77f6e916e3f9f5cc2fb9ae16fcf285af66f412a34325124f4a00e
+          # Renovate updates the line below. Please keep its formatting as it is.
+          renovate-version: 37.420.1
           token: '${{ steps.generate-token.outputs.token }}'
         env:
           GITHUB_COM_TOKEN: ${{ secrets.GRAFANABOT_PAT }}


### PR DESCRIPTION
By having renovate update itself, we get two nice benefits:
1. We keep renovate itself up to date
2. We keep the renovate config validation workflow in sync with the actual renovate workflow

This means that we get PRs updating renovate, while also having CI/CD tell us if we need to make changes to the config in those PRs.