### PR TITLE
Sync renovate configuration with other repos

### DIFF
--- a/.github/renovate-app.json
+++ b/.github/renovate-app.json
@@ -1,0 +1,7 @@
+{
+  "customEnvVariables": {
+    "GOPRIVATE": "github.com/grafana",
+    "GONOSUMDB": "github.com/grafana",
+    "GONOPROXY": "github.com/grafana"
+  }
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,8 +5,8 @@
     ":semanticCommitsDisabled"
   ],
 
-
   "branchPrefix": "grafanarenovatebot/",
+  "commitMessagePrefix": "Chore: ",
   // Used when renovate runs as a github app.
   // https://docs.renovatebot.com/configuration-options/#platformcommit
   // Setting platformCommit to `true`, as required by Grafana policy, seems to make renovate think all PRs are modified,
@@ -15,18 +15,40 @@
   "platformCommit": true,
   "dependencyDashboard": false,
   "forkProcessing": "disabled",
+  "rebaseWhen": "behind-base-branch",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 10,
+  "branchConcurrentLimit": 10,
+
+  "enabledManagers": ["custom.regex", "gomod"],
+
+  "labels": ["dependencies"],
+
+  "gomod": {
+    "enabled": true
+  },
 
   "postUpdateOptions": [
     "gomodTidyE"
   ],
 
-  "packageRules" : [
+  "packageRules": [
     {
       // Non-versioned go modules are noisy, with almost daily updates. We throttle them a bit.
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["digest"],
       "schedule": "before 8am on monday every 2 weeks",
     },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": "github.com/prometheus/*",
+      "groupName": "prometheus-go"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": "go.opentelemetry.io/**",
+      "groupName": "otel-go"
+    }
   ],
 
   "customManagers": [
@@ -36,11 +58,12 @@
       "depNameTemplate": "ghcr.io/grafana/grafana-build-tools",
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver",
+      "registryUrlTemplate": "https://ghcr.io",
       "fileMatch": [
-        "^\\.github/workflows/.*\\.ya?ml$",
         "(^|/)Makefile$",
         ".*\\.jsonnet$",
-        ".*\\.mk$"
+        ".*\\.mk$",
+        "^\\.github/workflows/.*\\.ya?ml$"
       ],
       "matchStrings": [
         "ghcr.io/grafana/grafana-build-tools:(?<currentValue>\\S+)"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,45 +1,48 @@
 name: Renovate
+
 on:
   schedule:
-    - cron:  '0 */4 * * *'
+    - cron:  '18 */4 * * *'
   workflow_dispatch:
+
 jobs:
   renovate:
     permissions:
-      contents: read
+      contents: read        # needed to read the contents of the repository
+      id-token: write       # needed to create a GitHub App token
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Generate token
-        id: generate-token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
+
+      - name: retrieve secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f0dd3480fa3e657d741dd9e8d9b999cfb61fc713
         with:
-          revoke: true
-          app_id: ${{ secrets.RENOVATEGRAFANA_ID }}
-          private_key: ${{ secrets.RENOVATEGRAFANA_PEM }}
+          common_secrets: |
+            GRAFANA_RENOVATE_APP_ID=grafana-renovate-app:app-id
+            GRAFANA_RENOVATE_PRIVATE_KEY=grafana-renovate-app:private-key
+
+      - name: create GitHub app token
+        id: app-token
+        # Beware that the token generated here has elevated permissions wrt to
+        # the ones set in the action. In particular, it will be able to write
+        # to the repository (e.g. create branches) and create pull requests.
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GRAFANA_RENOVATE_APP_ID }}
+          private-key: ${{ env.GRAFANA_RENOVATE_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@dd4d265eb8646cd04fc5f86ff8bc8d496d75a251 # v40.2.8
         with:
           renovate-version: 37.420.1@sha256:528f003c9aa77f6e916e3f9f5cc2fb9ae16fcf285af66f412a34325124f4a00e
-          token: '${{ steps.generate-token.outputs.token }}'
+          configurationFile: .github/renovate-app.json
+          token: '${{ steps.app-token.outputs.token }}'
         env:
-          GITHUB_COM_TOKEN: ${{ secrets.GRAFANABOT_PAT }}
           LOG_LEVEL: debug
-          RENOVATE_DETECT_HOST_RULES_FROM_ENV: true
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_USERNAME: GrafanaRenovateBot
-          GO_GITHUB_COM_HOSTTYPE: go
-          GO_GITHUB_COM_TOKEN: ${{ secrets.GRAFANABOT_PAT }}
-          GO_GITHUB_COM_GRAFANA_HOSTTYPE: go
-          GO_GITHUB_COM_GRAFANA_TOKEN: ${{ secrets.GRAFANABOT_PAT }}
-          GO_HTTPS___GITHUB_COM_HOSTTYPE: go
-          GO_HTTPS___GITHUB_COM_TOKEN: ${{ secrets.GRAFANABOT_PAT }}
-          GO_HTTPS___GITHUB_COM_GRAFANA_HOSTTYPE: go
-          GO_HTTPS___GITHUB_COM_GRAFANA_TOKEN: ${{ secrets.GRAFANABOT_PAT }}
-          GO_HTTPS_GITHUB_COM_HOSTTYPE: go
-          GO_HTTPS_GITHUB_COM_TOKEN: ${{ secrets.GRAFANABOT_PAT }}
-          GO_HTTPS_GITHUB_COM_GRAFANA_HOSTTYPE: go
-          GO_HTTPS_GITHUB_COM_GRAFANA_TOKEN: ${{ secrets.GRAFANABOT_PAT }}

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,5 @@
+{
+	"remediateSettings": {
+		"enableRenovate": false
+	}
+}


### PR DESCRIPTION
Pull changes from other repos to sync the renovate configuration.

* Set up group for prometheus dependencies
* Set up group for open telemetry dependencies
* Set environment variables for Go
* Set up limits on PR creation
* Use secrets from Vault to gain access to GitHub API
* Remove env variables that aren't needed (or used)