### PR TITLE
crocochrome: add histogram for chromium RSS usage

### DIFF
--- a/crocochrome.go
+++ b/crocochrome.go
@@ -320,6 +320,12 @@ func (s *Supervisor) launch(ctx context.Context, sessionID string) error {
 	}
 
 	if cmd.ProcessState != nil {
+		if rUsage, isSyscallRusage := cmd.ProcessState.SysUsage().(*syscall.Rusage); rUsage != nil && isSyscallRusage {
+			s.metrics.ChromiumResources.With(map[string]string{
+				metrics.Resource: metrics.ResourceRSS,
+			}).Observe(float64(rUsage.Maxrss * 1024)) // Convert from KiB to Bytes, as it is conventional in metrics.
+		}
+
 		attrs = append(attrs,
 			slog.Attr{Key: "pid", Value: slog.IntValue(cmd.ProcessState.Pid())},
 			slog.Attr{Key: "exitCode", Value: slog.IntValue(cmd.ProcessState.ExitCode())},


### PR DESCRIPTION
This PR adds a new histogram, `chromium_resource_usage`, which can be used to track chromium resources over time. For now it only tracks the peak RSS (resident segment size) in the `rss` label.

As chromium is naturally multiprocess, I'm in fact not positive that this metric is accounting for memory usage of all subprocesses, but in any case it can be an approximation to the problem.