### PR TITLE
ci: build for linux/arm64 in addition to linux/amd64

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -8,9 +8,9 @@ permissions:
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   publish:
@@ -25,6 +25,9 @@ jobs:
           echo "name=$(basename '${{ github.repository }}')" >> $GITHUB_OUTPUT
           echo "version=$(./scripts/version)" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
+      # grafana/shared-workflows/actions/push-to-gar-docker runs setup-buildx, but not setup-qemu.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Login to Google Artifact Registry
         uses: grafana/shared-workflows/actions/login-to-gar@main
       - name: Build container and push to GAR
@@ -34,3 +37,4 @@ jobs:
           tags: |-
             ${{ steps.repo.outputs.version }}
           push: true
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/push-pr.yaml
+++ b/.github/workflows/push-pr.yaml
@@ -32,9 +32,16 @@ jobs:
     name: Build container image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: |
-          make build-container
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build contianer
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          tags: ci.local/crocochrome:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
 
   golangci:
     name: Lint


### PR DESCRIPTION
This PR slightly modifies the build pipeline to also build the container image for `linux/arm64`, both for PR validation and releases. The `Dockerfile` was multiarch from the beginning, and alpine has fully featured arm images with chromium.