### PR TITLE
ci: set up docker buildx before attempting multiplatform build

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -26,6 +26,8 @@ jobs:
       # grafana/shared-workflows/actions/push-to-gar-docker runs setup-buildx, but not setup-qemu.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log into ghcr.io
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Otherwise, docker build is not able to use buildkit, and multiplatform build fails.