### PR TITLE
fix registry name in publish workflow

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -38,6 +38,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           tags: |-
-            ${{ github.repository }}:${{ steps.repo.outputs.version }}
+            ghcr.io/${{ github.repository }}:${{ steps.repo.outputs.version }}
           push: true
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Otherwise, CI/CD tries to push to docker hub, which is not what we want here.