### PR TITLE
ci/renovate: use shared renovate presets and actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,90 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    ":semanticCommitsDisabled"
+    "github>grafana/sm-renovate//presets/grafana.json5",
+    "github>grafana/sm-renovate//presets/synthetic-monitoring.json5",
+    "github>grafana/sm-renovate//presets/go.json5",
   ],
-
-  "branchPrefix": "grafanarenovatebot/",
-  "commitMessagePrefix": "Chore: ",
-  // Used when renovate runs as a github app.
-  // https://docs.renovatebot.com/configuration-options/#platformcommit
-  // Setting platformCommit to "enabled", as required by Grafana policy, seems to make renovate think all PRs are modified,
-  // as the dynamic author configured by github does not match the author set in `gitAuthor`. It is recommended to
-  // leave it unset: https://github.com/renovatebot/renovate/discussions/29106.
-  "platformCommit": "enabled",
-  "dependencyDashboard": false,
-  "forkProcessing": "disabled",
-  "rebaseWhen": "behind-base-branch",
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 10,
-  "branchConcurrentLimit": 10,
-
-  "enabledManagers": ["custom.regex", "gomod"],
-
-  "labels": ["dependencies"],
-
-  "gomod": {
-    "enabled": true
-  },
-
-  "postUpdateOptions": [
-    "gomodTidyE"
-  ],
-
-  "packageRules": [
-    {
-      // Non-versioned go modules are noisy, with almost daily updates. We throttle them a bit.
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["digest"],
-      "schedule": "before 8am on monday every 2 weeks",
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchPackageNames": "github.com/prometheus/*",
-      "groupName": "prometheus-go"
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchPackageNames": "go.opentelemetry.io/**",
-      "groupName": "otel-go"
-    },
-    {
-      "matchPackageNames": "**/renovate",
-      "extends": ["schedule:weekly"]
-    }
-  ],
-
-  "customManagers": [
-    {
-      // Update grafana-build-tools tags across the repository.
-      "customType": "regex",
-      "depNameTemplate": "ghcr.io/grafana/grafana-build-tools",
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver",
-      "registryUrlTemplate": "https://ghcr.io",
-      "fileMatch": [
-        "(^|/)Makefile$",
-        ".*\\.jsonnet$",
-        ".*\\.mk$",
-        "^\\.github/workflows/.*\\.ya?ml$"
-      ],
-      "matchStrings": [
-        "ghcr.io/grafana/grafana-build-tools:(?<currentValue>\\S+)"
-      ]
-    },
-    {
-      // Update renovate version in GHA workflow file.
-      "customType": "regex",
-      "depNameTemplate": "ghcr.io/renovatebot/renovate",
-      "datasourceTemplate": "docker",
-      "fileMatch": [
-        "^\\.github/workflows/.*\\.ya?ml$",
-      ],
-      "matchStrings": [
-        "renovate-version: (?<currentValue>[^@\\s]+)(?:@(?<currentDigest>\\S+))?",
-        "RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>\\S+))?"
-      ]
-    },
-  ],
+  "commitMessagePrefix": "",
 }

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -2,16 +2,23 @@ name: Validate renovate config
 on:
   pull_request:
     paths:
-      - "**renovate*.*"
+      # When renovate config changes:
+      - "renovate.*"
+      - ".renovate.*"
+      - ".github/renovate.*"
+      # Also when renovate version changes:
+      - ".github/workflows/renovate*"
+
 jobs:
-  validate:
+  renovate:
+    permissions:
+      # Needed for logging into vault.
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout Code
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: Validate renovate config
-        run: |-
-          # Renovate updates the line below. Please keep its formatting as it is.
-          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:39.29.0@sha256:9ac3737e9d3402494cd1a538f9689ed0ddb5dfc8e6dfc2dfc6c0a53ef452d716
-          docker run -i --rm -v $(realpath .):/repo -w /repo --entrypoint renovate-config-validator "$RENOVATE_IMAGE" --strict
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Self-hosted renovate
+        uses: grafana/sm-renovate/actions/renovate-validate@main

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,46 +1,20 @@
-name: Renovate
+name: Self-hosted Renovate
 
 on:
   schedule:
-    - cron: "18 */4 * * *"
+    - cron: "22 */4 * * *"
   workflow_dispatch:
 
 jobs:
   renovate:
     permissions:
-      contents: read # needed to read the contents of the repository
-      id-token: write # needed to create a GitHub App token
+      # Needed for logging into vault.
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout Code
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: retrieve secrets
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@332fb1cf3349234b5b1940f3f2797410e6ccd5d2
-        with:
-          common_secrets: |
-            GRAFANA_RENOVATE_APP_ID=grafana-renovate-app:app-id
-            GRAFANA_RENOVATE_PRIVATE_KEY=grafana-renovate-app:private-key
-
-      - name: create GitHub app token
-        id: app-token
-        # Beware that the token generated here has elevated permissions wrt to
-        # the ones set in the action. In particular, it will be able to write
-        # to the repository (e.g. create branches) and create pull requests.
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ env.GRAFANA_RENOVATE_APP_ID }}
-          private-key: ${{ env.GRAFANA_RENOVATE_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Self-hosted Renovate
-        uses: renovatebot/github-action@dd4d265eb8646cd04fc5f86ff8bc8d496d75a251 # v40.2.8
-        with:
-          renovate-version: 39.29.0@sha256:9ac3737e9d3402494cd1a538f9689ed0ddb5dfc8e6dfc2dfc6c0a53ef452d716
-          configurationFile: .github/renovate-app.json
-          token: "${{ steps.app-token.outputs.token }}"
-        env:
-          LOG_LEVEL: debug
-          RENOVATE_PLATFORM: github
-          RENOVATE_REPOSITORIES: ${{ github.repository }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Self-hosted renovate
+        uses: grafana/sm-renovate/actions/renovate@main


### PR DESCRIPTION
In line with
https://github.com/grafana/sm-k6-runner/pull/353
https://github.com/grafana/synthetic-monitoring-agent/pull/1067