### PR TITLE
version: do not append `0-hash` to version strings from a clean tag

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-git describe --dirty --tags --long --always
+git describe --dirty --tags --always


### PR DESCRIPTION
Before this PR, the `version` script would always append `-0-hash`, even when on a clean tag. For example:
```
nadia@Nadiarch  ±8a885e5 ✓ 󱃾 curry-admin@Curry
16:18:08 ~/Devel/crocochrome $> git describe --dirty --tags --long
v0.3.1-0-g8a885e5
```

After this change, if run on a tagged commit without changes w.r.t. the tag, the output will just be the tag name:
```
nadia@Nadiarch  ±8a885e5 ✓ 󱃾 curry-admin@Curry
16:18:11 ~/Devel/crocochrome $> git describe --dirty --tags --always
v0.3.1
```

This short name should be sufficiently descriptive, and more semver-compliant.