### PR TITLE
renovate: use `loose` versioning for chromium-swiftshader-alpine

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,4 +6,15 @@
     "github>grafana/sm-renovate//presets/go.json5",
   ],
   "commitMessagePrefix": "",
+  "packageRules": [
+    {
+      // The default "docker" versioning will try to restrict upgrades to versions that do not change everything after
+      // a dash (-) for the current tag, as this typically indicates the "flavor" (e.g. postgresql:17.1-alpine will not
+      // be upgraded to postgresql:17.2-debian).
+      // This image in particular has lots of dashes and does not follow this convention, so we force "loose"
+      // versioning which is pretty much an alphabetical sort.
+      "matchPackageNames": ["ghcr.io/grafana/chromium-swiftshader-alpine"],
+      "versioning": "loose",
+    },
+  ],
 }


### PR DESCRIPTION
The default "docker" versioning will try to restrict upgrades to versions that do not change everything after a dash (-) for the current tag, as this typically indicates the "flavor" (e.g. postgresql:17.1-alpine will not be upgraded to postgresql:17.2-debian).
This image in particular has lots of dashes and does not follow this convention, so we force "loose" versioning which is pretty much an alphabetical sort.
