### PR TITLE
ci: publish container images only for tags

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -6,8 +6,6 @@ permissions:
 
 on:
   push:
-    branches:
-      - "main"
     tags:
       - "v*"
 


### PR DESCRIPTION
At an earlier development phase, it made sense to publish every crocochrome commit to main as a tagged image. However, as we reach some stability in functionality, this does not seem to be needed anymore, and we can resort to manually created releases.