### PR TITLE
Set chromium's `oom_score_adj` to 1000, making it very killable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,8 @@ func main() {
 		ChromiumPath: "chromium",
 		// Id for nobody user and group on alpine.
 		UserGroup: 65534,
+		// Make chromium very attractive to the OOM killer, so it doesn't kill us.
+		OOMScoreAdj: 1000,
 		// In production we mount an emptyDir here, as opposed to /tmp, and configure chromium to write everything in
 		// /chromium-tmp instead. We do this to make sure we are not accidentally allowing things we don't know about
 		// to be written, as it is safe to assume that anything writing here (the only writable path) is doing so


### PR DESCRIPTION
Alternatively to making the supervisor hard to kill (https://github.com/grafana/crocochrome/pull/104) we can make the browser easy to kill.
This should hint the kernel to kill chromium first when the container starts memory starving.

The main problem with this approach is that chromium is multiprocessed, and the immediate child of crocochrome, which is the one we can make an easy target, is most likely not the one using the most memory.