### PR TITLE
chore: renovate: use prefix from preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,6 @@
     "github>grafana/sm-renovate//presets/synthetic-monitoring.json5",
     "github>grafana/sm-renovate//presets/go.json5",
   ],
-  "commitMessagePrefix": "",
   "customManagers": [
     {
       // Update k6 image used for integration tests only.


### PR DESCRIPTION
Now that release-please, and thus conventional commits have found this repo, renovate should obey those conventions, as much as that hurts me.