### PR TITLE
chore: remove integration test memory limit, make docker dep indirect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/grafana/crocochrome
 go 1.23
 
 require (
-	github.com/docker/docker v27.5.1+incompatible
 	github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c
 	github.com/prometheus/client_golang v1.21.0
 	github.com/testcontainers/testcontainers-go v0.35.0
@@ -22,6 +21,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/docker v27.5.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/grafana/crocochrome"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/exec"
@@ -55,9 +54,6 @@ func TestIntegration(t *testing.T) {
 			// Since https://github.com/grafana/crocochrome/pull/12, crocochrome requires /chromium-tmp to exist
 			// and be writable.
 			Mounts: testcontainers.Mounts(testcontainers.VolumeMount("chromium-tmp", "/chromium-tmp")),
-			Resources: container.Resources{
-				Memory: 750 << 20, // Megabytes.
-			},
 		},
 	})
 	testcontainers.CleanupContainer(t, cc)
@@ -78,9 +74,6 @@ func TestIntegration(t *testing.T) {
 			Image:      "grafana/k6:0.57.0",
 			Entrypoint: []string{"/bin/sleep", "infinity"},
 			Networks:   []string{network.Name},
-			Resources: container.Resources{
-				Memory: 250 << 20, // Megabytes.
-			},
 		},
 	})
 	testcontainers.CleanupContainer(t, cc)


### PR DESCRIPTION
Limiting the memory of the integration test container does not serve a very strong purpose, as the test scripts used for it are very simple anyway, and it is extremely unlikely for them to reach the previously specify limit of 750Mi.

Setting this limit however, promotes `docker` to a direct dependency, which causes it to be updated (e.g. https://github.com/grafana/crocochrome/pull/145), and potentially risk compatibility issues with testcontainers.

Overall, benefits of doing this are almost nil, and the nuance it causes is small but still larger than the benefits, in my opinion.