### PR TITLE
ci: do not use buildx cache for releases

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -32,7 +32,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
-
+        with:
+          cache-binary: false # https://woodruffw.github.io/zizmor/audits/#cache-poisoning
       - name: Log into ghcr.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:


### PR DESCRIPTION
https://woodruffw.github.io/zizmor/audits/#cache-poisoning