### PR TITLE
feat: ci: run test suite on arm

### DIFF
--- a/.github/workflows/push-pr.yaml
+++ b/.github/workflows/push-pr.yaml
@@ -29,7 +29,11 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ ubuntu-latest, ubuntu-24.04-arm ]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
This PR makes the CI/CD suite run on arm in addition to amd64, which provides additional guarantees to ensure we're not breaking anything arch-specific.

This is particularly useful for the recently added (#45) integration test suit, as it ensures that not only this project, but also Chromium and k6 are able to run a browser test on arm successfully.