### PR TITLE
chore: add renovate-approve workflow

### DIFF
--- a/.github/workflows/renovate-approve.yaml
+++ b/.github/workflows/renovate-approve.yaml
@@ -1,0 +1,17 @@
+name: Approve renovate PRs
+
+on:
+  pull_request:
+
+jobs:
+  approve:
+    permissions:
+      # Needed for logging into vault.
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    # Do not bother running if PR is not authored by grafanarenovatebot.
+    # https://woodruffw.github.io/zizmor/audits/#bot-conditions
+    if: github.event.pull_request.user.login == 'grafanarenovatebot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
+    steps:
+      - uses: grafana/sm-renovate/actions/renovate-approve@main


### PR DESCRIPTION
This PR adds a workflow that approves PRs coming from renovate automatically. This fulfills one of the three requirements for a PR to be merged without human supervision:
- PR is approved (what this PR does)
- CI/CD passes (depending on each particular renovate PR)
- Renovate requests automerge (we will configure renovate to do this very selectively on a separate PR)