### PR TITLE
chore: renovate: include grafana-build-tools preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   "extends": [
     "github>grafana/sm-renovate//presets/grafana.json5",
     "github>grafana/sm-renovate//presets/synthetic-monitoring.json5",
+    "github>grafana/sm-renovate//presets/grafana-build-tools.json5",
     "github>grafana/sm-renovate//presets/go.json5",
   ],
   "ignorePresets": [


### PR DESCRIPTION
Currently, the grafana-build-tools image used for building is being kept up to date, as it just like any other container image in the `Dockerfile`. However, there is also a reference to grafana-build-tools in the `Makefile`, which was not being updated by renovate.

Including the shared preset fixes this.