### PR TITLE
feat: Chromium memory observability via kernel accounting

### DIFF
--- a/cmd/crocochrome/main.go
+++ b/cmd/crocochrome/main.go
@@ -24,8 +24,9 @@ import (
 )
 
 type Config struct {
-	UserGroup int
-	TempDir   string
+	UserGroup            int
+	TempDir              string
+	EnableProcessMetrics bool
 }
 
 func main() {
@@ -36,6 +37,7 @@ func main() {
 	config := &Config{}
 	flag.StringVar(&config.TempDir, "temp-dir", "/chromium-tmp", "Directory for chromiumium instances to write their data to")
 	flag.IntVar(&config.UserGroup, "user-group", 65534, "Default user to run as. For local development, set this flag to 0")
+	flag.BoolVar(&config.EnableProcessMetrics, "process-metrics", false, "Enable per-process RSS collection at session teardown. Adds negligible overhead.")
 
 	flag.Parse()
 	if err := run(logger, config); err != nil {
@@ -66,9 +68,10 @@ func run(logger *slog.Logger, config *Config) error {
 		// /chromium-tmp instead. We do this to make sure we are not accidentally allowing things we don't know about
 		// to be written, as it is safe to assume that anything writing here (the only writable path) is doing so
 		// because we told it to.
-		TempDir:      config.TempDir,
-		Registry:     registry,
-		ExtraUATerms: "GrafanaSyntheticMonitoring",
+		TempDir:              config.TempDir,
+		Registry:             registry,
+		ExtraUATerms:         "GrafanaSyntheticMonitoring",
+		EnableProcessMetrics: config.EnableProcessMetrics,
 	})
 
 	err := supervisor.ComputeUserAgent(context.Background())

--- a/doc/chromium-observability.md
+++ b/doc/chromium-observability.md
@@ -1,0 +1,175 @@
+# Chromium Observability
+
+crocochrome exposes two sources of observability for Chromium sessions: structured
+log entries emitted at session teardown and a Prometheus counter for OOM kills.
+Together they allow operators to understand per-check memory usage, attribute that
+usage to specific Chromium process types, and detect kernel OOM kills.
+
+## Enabling
+
+The OOM kill counter (`sm_crocochrome_chromium_oom_kills_total`) is always active.
+Per-process RSS collection is opt-in:
+
+```
+crocochrome -process-metrics
+```
+
+Without this flag, no new log entries are emitted and behaviour is identical to
+before this feature was introduced. The Prometheus metrics are registered
+unconditionally but will have zero observations when the flag is off.
+
+---
+
+## Log entries
+
+Two structured log entries are emitted per session at teardown, both at `INFO`
+level. Every entry carries the session context fields `sessionID`, `id`
+(check ID), `tenantID`, and `regionID`, which can be used to correlate entries
+across the two types and across multiple executions of the same check.
+
+### `chromium process memory`
+
+One entry per OS process found in the container cgroup at teardown. Covers every
+process running inside the container — Chromium subprocesses as well as crocochrome
+and its supervisor.
+
+| Field | Description |
+|---|---|
+| `processType` | Process classification (see table below) |
+| `pid` | OS process ID |
+| `rss` | Current resident set size in bytes at the moment of collection |
+| `peakRSS` | Peak RSS since the process started (Linux `VmHWM`), in bytes |
+
+**Process types:**
+
+| Type | What it is |
+|---|---|
+| `browser` | Main Chromium browser process |
+| `renderer` | Renderer process (Blink + V8); one or more per session depending on site isolation |
+| `gpu-process` | GPU compositor (SwiftShader software renderer in containers) |
+| `network-service` | Network service utility |
+| `utility` | Other Chromium utility process (e.g. storage service) |
+| `zygote` | Chromium zygote — the process-spawning intermediary |
+| `crashpad` | Crash reporting handler; ~2 MiB, noise for memory analysis |
+| `crocochrome` | The crocochrome binary itself |
+| `tini` | Container init process; ~0 MiB, noise for memory analysis |
+| `unknown` | Process exited before cmdline could be read (expected race at teardown) |
+
+**Important caveats on `rss` and `peakRSS`:**
+
+- **Do not sum `rss` across entries.** Each process's `rss` includes shared library
+  pages that are physically shared between processes but counted once per process in
+  `VmRSS`. Summing across a session inflates the total by approximately 4–5×. Use
+  `cgroupRSS` from `chromium session memory` for the accurate container total.
+- **`peakRSS` is the session peak for Chromium subprocesses** because they are
+  spawned fresh per session. For `crocochrome` and `tini`, which persist across
+  sessions, it reflects the peak since container start.
+- **`rss` is a point-in-time snapshot at teardown**, not the peak. A process that
+  spiked and freed memory before teardown will show a lower `rss` but a higher
+  `peakRSS`.
+
+---
+
+### `chromium session memory`
+
+One entry per session. Provides the accurate container-level memory total and
+process count.
+
+| Field | Description |
+|---|---|
+| `cgroupRSS` | Total memory used by all processes in the container cgroup, in bytes. Kernel-maintained; deduplicates shared pages. This is the ground truth for "how much memory did this check use." |
+| `processCount` | Number of processes found in the cgroup at teardown |
+
+`cgroupRSS` is read from `memory.current` (cgroupsv2) or `memory.usage_in_bytes`
+(cgroupsv1). Unlike the sum of per-process `rss` values, it counts each physical
+page exactly once regardless of how many processes share it.
+
+Note: `cgroupRSS` is a point-in-time value read at the end of the session. For
+sessions that were OOM-killed, the killed processes have already freed their memory
+by teardown time, so `cgroupRSS` will be lower than the peak that triggered the kill.
+
+---
+
+## Prometheus metrics
+
+### `sm_crocochrome_chromium_oom_kills_total`
+
+Counter. Incremented once per process killed by the kernel OOM killer within the
+container cgroup during a session. Detected by sampling the cgroup `oom_kill`
+counter before and after `cmd.Run()`.
+
+A non-zero rate indicates the container's memory limit was exceeded and the kernel
+intervened. Unlike `signal: killed` in process exit logs (which is identical for
+both OOM kills and normal SIGKILL teardown), this counter distinguishes the two.
+
+Always active; does not require `-process-metrics`.
+
+---
+
+## Practical queries
+
+### Loki
+
+**Total memory used by a specific check over time:**
+```logql
+{namespace="sm-k6-mq", container="crocochrome"}
+  |= "chromium session memory"
+  | json
+  | id=`<check-id>`
+  | unwrap cgroupRSS
+  | __error__=""
+```
+
+**Checks exceeding a memory threshold:**
+```logql
+{namespace="sm-k6-mq", container="crocochrome"}
+  |= "chromium session memory"
+  | json
+  | cgroupRSS > 1073741824
+  | line_format "check={{.id}} tenant={{.tenantID}} total={{.cgroupRSS}}"
+```
+
+**Per-process-type memory breakdown for a specific check:**
+```logql
+{namespace="sm-k6-mq", container="crocochrome"}
+  |= "chromium process memory"
+  | json
+  | id=`<check-id>`
+  | line_format "type={{.processType}} rss={{.rss}} peak={{.peakRSS}}"
+```
+
+**GPU process peak RSS trend for a specific check:**
+```logql
+{namespace="sm-k6-mq", container="crocochrome"}
+  |= "chromium process memory"
+  | json
+  | id=`<check-id>` and processType=`gpu-process`
+  | unwrap peakRSS
+  | __error__=""
+```
+
+### Prometheus
+
+**OOM kill rate across the fleet:**
+```promql
+rate(sm_crocochrome_chromium_oom_kills_total[5m])
+```
+
+**OOM kills as a fraction of finished sessions:**
+```promql
+rate(sm_crocochrome_chromium_oom_kills_total[5m])
+  /
+rate(sm_crocochrome_chromium_executions_total{state="finished"}[5m])
+```
+
+---
+
+## Summary of caveats
+
+| Caveat | Detail |
+|---|---|
+| Don't sum per-process `rss` | Use `cgroupRSS` for the accurate container total; per-process VmRSS counts shared pages multiple times |
+| `rss` is a teardown snapshot | Use `peakRSS` to understand the high-water mark; `rss` may be lower if memory was freed before teardown |
+| `peakRSS` scope | For Chromium subprocesses (fresh per session) this equals the session peak. For `crocochrome` and `tini` it reflects the container lifetime peak |
+| OOM-killed sessions | `cgroupRSS` at teardown shows post-kill state (killed processes have freed memory). The OOM kill counter is the right signal; `cgroupRSS` from healthy sessions shows the trend leading up to it |
+| OOM kill attribution | The `oom_kill` delta is per-session but counts kills in the container cgroup — a lingering process from a prior session could in rare cases increment the counter for the current session |

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/internal/crocochrome/cgroup.go
+++ b/internal/crocochrome/cgroup.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs"
 )
 
 const (
@@ -18,9 +20,6 @@ const (
 	// cgroupV1OOMControl is the path template for the cgroups v1 memory OOM control file.
 	// The actual path is constructed by reading /proc/self/cgroup.
 	cgroupV1OOMControl = "/sys/fs/cgroup/memory%s/memory.oom_control"
-
-	// procSelfCgroup is the standard path for the calling process's cgroup memberships.
-	procSelfCgroup = "/proc/self/cgroup"
 )
 
 // detectCgroupMemoryEventsPath returns the path to the file that contains the cgroup OOM kill
@@ -31,36 +30,37 @@ const (
 //  1. cgroupsv2: /sys/fs/cgroup/memory.events
 //  2. cgroupsv1: /sys/fs/cgroup/memory/<hierarchy-path>/memory.oom_control (derived from
 //     /proc/self/cgroup)
-func detectCgroupMemoryEventsPath() string {
+func detectCgroupMemoryEventsPath(procRoot string) string {
 	if _, err := os.Stat(cgroupV2MemoryEvents); err == nil {
 		return cgroupV2MemoryEvents
 	}
 
-	return cgroupV1MemoryOOMControlPath(procSelfCgroup)
+	return cgroupV1MemoryOOMControlPath(procRoot)
 }
 
-// cgroupV1MemoryOOMControlPath reads procSelfCgroupPath (/proc/self/cgroup) and returns the
-// memory.oom_control path for the memory controller hierarchy, or "" if it cannot be found.
-func cgroupV1MemoryOOMControlPath(procSelfCgroupPath string) string {
-	f, err := os.Open(procSelfCgroupPath)
+// cgroupV1MemoryOOMControlPath resolves the calling process's cgroupv1 memory hierarchy
+// via prometheus/procfs and returns the memory.oom_control path for that hierarchy, or
+// "" if the memory controller is not found or procfs cannot be opened.
+func cgroupV1MemoryOOMControlPath(procRoot string) string {
+	fs, err := procfs.NewFS(procRoot)
 	if err != nil {
 		return ""
 	}
-	defer f.Close() //nolint:errcheck
 
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		// Format: <hierarchy-id>:<controller-list>:<cgroup-path>
-		// e.g.   12:memory:/kubepods/besteffort/pod.../container-id
-		parts := strings.SplitN(scanner.Text(), ":", 3)
-		if len(parts) != 3 {
-			continue
-		}
+	self, err := fs.Self()
+	if err != nil {
+		return ""
+	}
 
-		controllers := strings.Split(parts[1], ",")
-		for _, c := range controllers {
+	cgs, err := self.Cgroups()
+	if err != nil {
+		return ""
+	}
+
+	for _, cg := range cgs {
+		for _, c := range cg.Controllers {
 			if c == "memory" {
-				return fmt.Sprintf(cgroupV1OOMControl, parts[2])
+				return fmt.Sprintf(cgroupV1OOMControl, cg.Path)
 			}
 		}
 	}

--- a/internal/crocochrome/cgroup.go
+++ b/internal/crocochrome/cgroup.go
@@ -1,0 +1,111 @@
+package crocochrome
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	// cgroupV2MemoryEvents is the unified-hierarchy memory events file present on cgroups v2.
+	// It contains a line "oom_kill <N>" that increments each time the kernel OOM-killer fires
+	// within this cgroup.
+	cgroupV2MemoryEvents = "/sys/fs/cgroup/memory.events"
+
+	// cgroupV1OOMControl is the path template for the cgroups v1 memory OOM control file.
+	// The actual path is constructed by reading /proc/self/cgroup.
+	cgroupV1OOMControl = "/sys/fs/cgroup/memory%s/memory.oom_control"
+
+	// procSelfCgroup is the standard path for the calling process's cgroup memberships.
+	procSelfCgroup = "/proc/self/cgroup"
+)
+
+// detectCgroupMemoryEventsPath returns the path to the file that contains the cgroup OOM kill
+// counter for the current process, or an empty string if neither cgroups v2 nor v1 can be
+// located.
+//
+// Priority:
+//  1. cgroupsv2: /sys/fs/cgroup/memory.events
+//  2. cgroupsv1: /sys/fs/cgroup/memory/<hierarchy-path>/memory.oom_control (derived from
+//     /proc/self/cgroup)
+func detectCgroupMemoryEventsPath() string {
+	if _, err := os.Stat(cgroupV2MemoryEvents); err == nil {
+		return cgroupV2MemoryEvents
+	}
+
+	return cgroupV1MemoryOOMControlPath(procSelfCgroup)
+}
+
+// cgroupV1MemoryOOMControlPath reads procSelfCgroupPath (/proc/self/cgroup) and returns the
+// memory.oom_control path for the memory controller hierarchy, or "" if it cannot be found.
+func cgroupV1MemoryOOMControlPath(procSelfCgroupPath string) string {
+	f, err := os.Open(procSelfCgroupPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close() //nolint:errcheck
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Format: <hierarchy-id>:<controller-list>:<cgroup-path>
+		// e.g.   12:memory:/kubepods/besteffort/pod.../container-id
+		parts := strings.SplitN(scanner.Text(), ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+
+		controllers := strings.Split(parts[1], ",")
+		for _, c := range controllers {
+			if c == "memory" {
+				return fmt.Sprintf(cgroupV1OOMControl, parts[2])
+			}
+		}
+	}
+
+	return ""
+}
+
+// readOOMKillCount reads the oom_kill counter from the given memory events file.
+// It handles both cgroups v2 (memory.events) and v1 (memory.oom_control) formats, as both
+// use a "oom_kill <N>" line (space-delimited; tabs are not used by any known kernel version).
+// Returns 0 and no error when the file is empty or the counter line is absent.
+// Returns an error only on I/O failure.
+func readOOMKillCount(path string) (uint64, error) {
+	if path == "" {
+		return 0, nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil // file absent in test environments; treat as zero
+		}
+
+		return 0, fmt.Errorf("opening cgroup memory events file %q: %w", path, err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "oom_kill ") {
+			continue
+		}
+
+		val, err := strconv.ParseUint(strings.TrimPrefix(line, "oom_kill "), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parsing oom_kill value from %q: %w", filepath.Base(path), err)
+		}
+
+		return val, nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("scanning cgroup memory events file %q: %w", path, err)
+	}
+
+	return 0, nil
+}

--- a/internal/crocochrome/cgroup_test.go
+++ b/internal/crocochrome/cgroup_test.go
@@ -109,11 +109,11 @@ func TestCgroupV1MemoryOOMControlPath(t *testing.T) {
 	t.Run("extracts memory controller path", func(t *testing.T) {
 		t.Parallel()
 
-		f := writeTempFile(t, `11:blkio:/kubepods
+		root := newFakeProcFS(t, `11:blkio:/kubepods
 12:memory:/kubepods/besteffort/podabc123/container456
 13:cpu,cpuacct:/kubepods
 `)
-		got := crocochrome.CgroupV1MemoryOOMControlPath(f)
+		got := crocochrome.CgroupV1MemoryOOMControlPath(root)
 		want := "/sys/fs/cgroup/memory/kubepods/besteffort/podabc123/container456/memory.oom_control"
 
 		if got != want {
@@ -124,21 +124,44 @@ func TestCgroupV1MemoryOOMControlPath(t *testing.T) {
 	t.Run("returns empty string when memory controller is absent", func(t *testing.T) {
 		t.Parallel()
 
-		f := writeTempFile(t, `11:blkio:/kubepods
+		root := newFakeProcFS(t, `11:blkio:/kubepods
 13:cpu,cpuacct:/kubepods
 `)
-		if got := crocochrome.CgroupV1MemoryOOMControlPath(f); got != "" {
+		if got := crocochrome.CgroupV1MemoryOOMControlPath(root); got != "" {
 			t.Fatalf("expected empty string, got %q", got)
 		}
 	})
 
-	t.Run("returns empty string for non-existent file", func(t *testing.T) {
+	t.Run("returns empty string for non-existent procfs root", func(t *testing.T) {
 		t.Parallel()
 
 		if got := crocochrome.CgroupV1MemoryOOMControlPath("/does/not/exist"); got != "" {
 			t.Fatalf("expected empty string, got %q", got)
 		}
 	})
+}
+
+// newFakeProcFS creates a tempdir that procfs.NewFS will accept as a procfs root,
+// containing a single pid directory with the given /proc/<pid>/cgroup contents and
+// a "self" symlink pointing at it. Returns the root path.
+func newFakeProcFS(t *testing.T, cgroupContents string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	const pid = "1234"
+
+	pidDir := filepath.Join(root, pid)
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatalf("creating pid dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "cgroup"), []byte(cgroupContents), 0o600); err != nil {
+		t.Fatalf("writing cgroup file: %v", err)
+	}
+	if err := os.Symlink(pid, filepath.Join(root, "self")); err != nil {
+		t.Fatalf("creating self symlink: %v", err)
+	}
+
+	return root
 }
 
 // writeTempFile writes content to a uniquely-named temp file and returns its path.

--- a/internal/crocochrome/cgroup_test.go
+++ b/internal/crocochrome/cgroup_test.go
@@ -1,0 +1,154 @@
+package crocochrome_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/crocochrome/internal/crocochrome"
+)
+
+func TestReadOOMKillCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns zero for empty path", func(t *testing.T) {
+		t.Parallel()
+
+		count, err := crocochrome.ReadOOMKillCount("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if count != 0 {
+			t.Fatalf("expected 0, got %d", count)
+		}
+	})
+
+	t.Run("returns zero for non-existent file", func(t *testing.T) {
+		t.Parallel()
+
+		count, err := crocochrome.ReadOOMKillCount("/does/not/exist/memory.events")
+		if err != nil {
+			t.Fatalf("unexpected error for missing file: %v", err)
+		}
+
+		if count != 0 {
+			t.Fatalf("expected 0, got %d", count)
+		}
+	})
+
+	t.Run("parses cgroupsv2 memory.events format", func(t *testing.T) {
+		t.Parallel()
+
+		f := writeTempFile(t, `low 0
+high 0
+max 5
+oom 2
+oom_kill 3
+oom_group_kill 0
+`)
+		count, err := crocochrome.ReadOOMKillCount(f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if count != 3 {
+			t.Fatalf("expected oom_kill=3, got %d", count)
+		}
+	})
+
+	t.Run("parses cgroupsv1 memory.oom_control format", func(t *testing.T) {
+		t.Parallel()
+
+		f := writeTempFile(t, `oom_kill_disable 0
+under_oom 0
+oom_kill 7
+`)
+		count, err := crocochrome.ReadOOMKillCount(f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if count != 7 {
+			t.Fatalf("expected oom_kill=7, got %d", count)
+		}
+	})
+
+	t.Run("returns zero when oom_kill line is absent", func(t *testing.T) {
+		t.Parallel()
+
+		f := writeTempFile(t, `low 0
+high 0
+max 0
+`)
+		count, err := crocochrome.ReadOOMKillCount(f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if count != 0 {
+			t.Fatalf("expected 0, got %d", count)
+		}
+	})
+
+	t.Run("returns error on malformed oom_kill value", func(t *testing.T) {
+		t.Parallel()
+
+		f := writeTempFile(t, "oom_kill notanumber\n")
+
+		_, err := crocochrome.ReadOOMKillCount(f)
+		if err == nil {
+			t.Fatal("expected error for malformed oom_kill value, got nil")
+		}
+	})
+}
+
+func TestCgroupV1MemoryOOMControlPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts memory controller path", func(t *testing.T) {
+		t.Parallel()
+
+		f := writeTempFile(t, `11:blkio:/kubepods
+12:memory:/kubepods/besteffort/podabc123/container456
+13:cpu,cpuacct:/kubepods
+`)
+		got := crocochrome.CgroupV1MemoryOOMControlPath(f)
+		want := "/sys/fs/cgroup/memory/kubepods/besteffort/podabc123/container456/memory.oom_control"
+
+		if got != want {
+			t.Fatalf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("returns empty string when memory controller is absent", func(t *testing.T) {
+		t.Parallel()
+
+		f := writeTempFile(t, `11:blkio:/kubepods
+13:cpu,cpuacct:/kubepods
+`)
+		if got := crocochrome.CgroupV1MemoryOOMControlPath(f); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("returns empty string for non-existent file", func(t *testing.T) {
+		t.Parallel()
+
+		if got := crocochrome.CgroupV1MemoryOOMControlPath("/does/not/exist"); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+}
+
+// writeTempFile writes content to a uniquely-named temp file and returns its path.
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test-cgroup-events")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+
+	return path
+}

--- a/internal/crocochrome/crocochrome.go
+++ b/internal/crocochrome/crocochrome.go
@@ -65,6 +65,11 @@ type Options struct {
 	// ExtraUATerms is appended, after a space, to the chromium user agent. It can be used to add vendor-specific
 	// information to it, such as the name of the product using chromium to perform requests.
 	ExtraUATerms string
+	// CgroupMemoryEventsPath is the path to the cgroup memory events file used to detect OOM kills.
+	// If empty, the path is auto-detected (cgroupsv2: /sys/fs/cgroup/memory.events,
+	// cgroupsv1: /sys/fs/cgroup/memory/<hierarchy>/memory.oom_control).
+	// Set to a non-existent path to disable OOM detection (e.g. in tests that do not need it).
+	CgroupMemoryEventsPath string
 }
 
 const (
@@ -94,6 +99,10 @@ func (o Options) withDefaults() Options {
 
 	if o.Registry == nil {
 		o.Registry = prometheus.NewRegistry() // Empty, unused.
+	}
+
+	if o.CgroupMemoryEventsPath == "" {
+		o.CgroupMemoryEventsPath = detectCgroupMemoryEventsPath()
 	}
 
 	return o
@@ -342,7 +351,30 @@ func (s *Supervisor) launch(ctx context.Context, logger *slog.Logger) error {
 		s.metrics.SessionDuration.Observe(time.Since(created).Seconds())
 	}()
 
+	// Sample the cgroup OOM kill counter before launching Chromium so we can detect
+	// any OOM kills that occur during this session (as opposed to prior sessions).
+	oomBefore, oomBeforeErr := readOOMKillCount(s.opts.CgroupMemoryEventsPath)
+	if oomBeforeErr != nil {
+		logger.Warn("could not read cgroup OOM kill count before session", "err", oomBeforeErr)
+	}
+
 	err = cmd.Run()
+
+	// Check whether the OOM killer fired during this session. Skip the comparison if the
+	// baseline read failed — incrementing against an unknown baseline (implicitly 0) would
+	// produce false positives. Also guard against counter wraparound/reset which would
+	// manifest as oomAfter < oomBefore.
+	if oomBeforeErr == nil {
+		if oomAfter, oomErr := readOOMKillCount(s.opts.CgroupMemoryEventsPath); oomErr != nil {
+			logger.Warn("could not read cgroup OOM kill count after session", "err", oomErr)
+		} else if oomAfter < oomBefore {
+			logger.Warn("cgroup OOM kill counter decreased unexpectedly (counter reset or cgroup recreated?)",
+				"before", oomBefore, "after", oomAfter)
+		} else if delta := oomAfter - oomBefore; delta > 0 {
+			logger.Warn("OOM kill(s) detected during session", "oomKills", delta)
+			s.metrics.OOMKills.Add(float64(delta))
+		}
+	}
 
 	attrs := make([]slog.Attr, 0, 9)
 

--- a/internal/crocochrome/crocochrome.go
+++ b/internal/crocochrome/crocochrome.go
@@ -70,6 +70,16 @@ type Options struct {
 	// cgroupsv1: /sys/fs/cgroup/memory/<hierarchy>/memory.oom_control).
 	// Set to a non-existent path to disable OOM detection (e.g. in tests that do not need it).
 	CgroupMemoryEventsPath string
+	// EnableProcessMetrics enables per-process RSS collection at session teardown.
+	// When true, Delete() walks cgroup.procs and reads VmRSS and VmHWM from
+	// /proc/<pid>/status for each process, emitting "chromium process memory" log entries
+	// and a "chromium session memory" summary with the cgroup-level total.
+	// This is fast (file reads only, no network) and adds negligible overhead to DELETE.
+	// Disabled by default; enable via the -process-metrics flag.
+	EnableProcessMetrics bool
+	// ProcFSRoot is the root of the proc filesystem used for per-process RSS and cmdline reads.
+	// Defaults to "/proc". Override in tests to point at a temp directory.
+	ProcFSRoot string
 }
 
 const (
@@ -105,6 +115,10 @@ func (o Options) withDefaults() Options {
 		o.CgroupMemoryEventsPath = detectCgroupMemoryEventsPath()
 	}
 
+	if o.ProcFSRoot == "" {
+		o.ProcFSRoot = "/proc"
+	}
+
 	return o
 }
 
@@ -127,6 +141,9 @@ type session struct {
 	info *SessionInfo
 	// cancel is the CancelFunc for this session, called on Delete and when the session times out.
 	cancel context.CancelFunc
+	// logger is the session-scoped logger enriched with sessionID, regionID, tenantID, and check id.
+	// Constructed in Create and used in goroutines that outlive it (e.g. Delete).
+	logger *slog.Logger
 }
 
 func New(logger *slog.Logger, opts Options) *Supervisor {
@@ -235,17 +252,75 @@ func (s *Supervisor) Create(checkInfo CheckInfo) (SessionInfo, error) {
 	s.sessions[id] = session{
 		cancel: cancel,
 		info:   &si,
+		logger: logger,
 	}
 
 	return si, nil
 }
 
 // Delete cancels a session's context and removes it from the map.
+// When -process-metrics is enabled, it collects per-process RSS from cgroup.procs before
+// sending SIGKILL, emitting "chromium process memory" log entries and a "chromium session
+// memory" summary. Collection is fast (file reads only) and best-effort.
+// When Delete is called concurrently for the same session (explicit DELETE racing the
+// AfterFunc timeout), both callers collect independently but only the goroutine that wins
+// the s.delete race emits log entries, deduplicating output.
 func (s *Supervisor) Delete(sessionID string) bool {
+	// Hoist the fields we need while holding the lock, then release before any I/O.
 	s.sessionsMtx.Lock()
-	defer s.sessionsMtx.Unlock()
+	sess, found := s.sessions[sessionID]
+	s.sessionsMtx.Unlock()
 
-	return s.delete(sessionID)
+	if !found {
+		return false
+	}
+
+	sessLogger := sess.logger
+
+	var (
+		processes []processInfo
+		cgroupRSS int64
+	)
+
+	// Per-process RSS — fast file reads only, no context or timeout required.
+	if s.opts.EnableProcessMetrics {
+		var procErr error
+		processes, cgroupRSS, procErr = collectProcessMetrics(s.opts.CgroupMemoryEventsPath, s.opts.ProcFSRoot)
+		if procErr != nil {
+			sessLogger.Debug("could not collect process metrics", "err", procErr)
+		}
+	}
+
+	// Re-acquire the lock and attempt deletion. If a concurrent caller already deleted
+	// this session, s.delete returns false and we emit nothing.
+	s.sessionsMtx.Lock()
+	deleted := s.delete(sessionID)
+	s.sessionsMtx.Unlock()
+
+	if !deleted {
+		return false
+	}
+
+	// We won the deletion race. Emit collected observability data.
+	// context.Background() is intentional: the session context is now cancelled and some
+	// slog handler implementations suppress output when the context is done.
+	for _, p := range processes {
+		sessLogger.LogAttrs(context.Background(), slog.LevelInfo, "chromium process memory",
+			slog.Int("pid", p.PID),
+			slog.String("processType", p.Type),
+			slog.Int64("rss", p.RSS),
+			slog.Int64("peakRSS", p.PeakRSS),
+		)
+	}
+
+	if s.opts.EnableProcessMetrics {
+		sessLogger.LogAttrs(context.Background(), slog.LevelInfo, "chromium session memory",
+			slog.Int64("cgroupRSS", cgroupRSS),
+			slog.Int("processCount", len(processes)),
+		)
+	}
+
+	return true
 }
 
 // Wait blocks until there are no sessions running.

--- a/internal/crocochrome/crocochrome.go
+++ b/internal/crocochrome/crocochrome.go
@@ -194,12 +194,12 @@ func (s *Supervisor) Create(checkInfo CheckInfo) (SessionInfo, error) {
 		// session has already been removed.
 		logger.Debug("context cancelled, removing session from the map")
 		s.Delete(id) // AfterFunc runs on a separate goroutine, so we want the mutex-locking version.
-		s.wg.Done()
 	})
 
 	// Launch chromium and wait for it to finish asynchronously.
 	// We do not wait for errors, as we probe chromium below. If something went wrong, we error out there.
 	go func() {
+		defer s.wg.Done()
 		err := s.launch(ctx, logger)
 		if err != nil {
 			logger.Error("launching chromium", "err", err)

--- a/internal/crocochrome/crocochrome.go
+++ b/internal/crocochrome/crocochrome.go
@@ -111,12 +111,12 @@ func (o Options) withDefaults() Options {
 		o.Registry = prometheus.NewRegistry() // Empty, unused.
 	}
 
-	if o.CgroupMemoryEventsPath == "" {
-		o.CgroupMemoryEventsPath = detectCgroupMemoryEventsPath()
-	}
-
 	if o.ProcFSRoot == "" {
 		o.ProcFSRoot = "/proc"
+	}
+
+	if o.CgroupMemoryEventsPath == "" {
+		o.CgroupMemoryEventsPath = detectCgroupMemoryEventsPath(o.ProcFSRoot)
 	}
 
 	return o

--- a/internal/crocochrome/crocochrome.go
+++ b/internal/crocochrome/crocochrome.go
@@ -258,54 +258,71 @@ func (s *Supervisor) Create(checkInfo CheckInfo) (SessionInfo, error) {
 	return si, nil
 }
 
-// Delete cancels a session's context and removes it from the map.
-// When -process-metrics is enabled, it collects per-process RSS from cgroup.procs before
-// sending SIGKILL, emitting "chromium process memory" log entries and a "chromium session
-// memory" summary. Collection is fast (file reads only) and best-effort.
-// When Delete is called concurrently for the same session (explicit DELETE racing the
-// AfterFunc timeout), both callers collect independently but only the goroutine that wins
-// the s.delete race emits log entries, deduplicating output.
+// Delete collects teardown observability data and cancels the session context (sending
+// SIGKILL to Chromium).
+//
+// Concurrency: takeSession atomically removes the session from the map AND cancels its
+// context under the same lock. This eliminates the race window where a concurrent Create
+// could find an empty map (no session to kill) and attempt to start a new Chromium on
+// the same port while the old one was still alive. Any concurrent caller sees either the
+// session in the map (and kills it via killExisting) or the session gone with SIGKILL
+// already in flight. No intermediate state is observable.
+//
+// Observability collection happens after cancel. SIGKILL is non-blocking: the kernel
+// schedules process cleanup but does not wait for it, so Chromium and its subprocesses
+// remain present in /proc and cgroup.procs for a brief window after the signal is sent.
+// emitTeardownObservability reads during this window and treats ENOENT (process exited
+// before read) as an expected race, skipping silently.
 func (s *Supervisor) Delete(sessionID string) bool {
-	// Hoist the fields we need while holding the lock, then release before any I/O.
-	s.sessionsMtx.Lock()
-	sess, found := s.sessions[sessionID]
-	s.sessionsMtx.Unlock()
-
+	sess, found := s.takeSession(sessionID)
 	if !found {
 		return false
 	}
 
-	sessLogger := sess.logger
+	s.emitTeardownObservability(sess)
 
-	var (
-		processes []processInfo
-		cgroupRSS int64
-	)
+	return true
+}
 
-	// Per-process RSS — fast file reads only, no context or timeout required.
-	if s.opts.EnableProcessMetrics {
-		var procErr error
-		processes, cgroupRSS, procErr = collectProcessMetrics(s.opts.CgroupMemoryEventsPath, s.opts.ProcFSRoot)
-		if procErr != nil {
-			sessLogger.Debug("could not collect process metrics", "err", procErr)
-		}
-	}
-
-	// Re-acquire the lock and attempt deletion. If a concurrent caller already deleted
-	// this session, s.delete returns false and we emit nothing.
+// takeSession atomically removes the session from the map, cancels its context (sending
+// SIGKILL to Chromium), and returns the session. Both operations happen under the same
+// lock so no caller can observe the session gone from the map without SIGKILL already
+// having been sent. Returns (session{}, false) if no session with that ID exists.
+func (s *Supervisor) takeSession(sessionID string) (session, bool) {
 	s.sessionsMtx.Lock()
-	deleted := s.delete(sessionID)
-	s.sessionsMtx.Unlock()
+	defer s.sessionsMtx.Unlock()
 
-	if !deleted {
-		return false
+	sess, found := s.sessions[sessionID]
+	if !found {
+		return session{}, false
 	}
 
-	// We won the deletion race. Emit collected observability data.
-	// context.Background() is intentional: the session context is now cancelled and some
-	// slog handler implementations suppress output when the context is done.
+	delete(s.sessions, sessionID)
+	sess.cancel()
+
+	return sess, true
+}
+
+// emitTeardownObservability collects and emits process metrics for the given session.
+// Called after takeSession (SIGKILL already sent) so the window in which process data is
+// readable is brief. ENOENT on any /proc read is treated as the process having already
+// exited and is skipped silently.
+// All collection is best-effort; errors are logged at Debug and do not affect teardown.
+func (s *Supervisor) emitTeardownObservability(sess session) {
+	if !s.opts.EnableProcessMetrics {
+		return
+	}
+
+	processes, cgroupRSS, procErr := collectProcessMetrics(s.opts.CgroupMemoryEventsPath, s.opts.ProcFSRoot)
+	if procErr != nil {
+		sess.logger.Debug("could not collect process metrics", "err", procErr)
+	}
+
+	// context.Background() is intentional: the session context is already cancelled
+	// (sess.cancel was called in takeSession) and some slog handler implementations
+	// suppress output when the provided context is done.
 	for _, p := range processes {
-		sessLogger.LogAttrs(context.Background(), slog.LevelInfo, "chromium process memory",
+		sess.logger.LogAttrs(context.Background(), slog.LevelInfo, "chromium process memory",
 			slog.Int("pid", p.PID),
 			slog.String("processType", p.Type),
 			slog.Int64("rss", p.RSS),
@@ -313,14 +330,10 @@ func (s *Supervisor) Delete(sessionID string) bool {
 		)
 	}
 
-	if s.opts.EnableProcessMetrics {
-		sessLogger.LogAttrs(context.Background(), slog.LevelInfo, "chromium session memory",
-			slog.Int64("cgroupRSS", cgroupRSS),
-			slog.Int("processCount", len(processes)),
-		)
-	}
-
-	return true
+	sess.logger.LogAttrs(context.Background(), slog.LevelInfo, "chromium session memory",
+		slog.Int64("cgroupRSS", cgroupRSS),
+		slog.Int("processCount", len(processes)),
+	)
 }
 
 // Wait blocks until there are no sessions running.

--- a/internal/crocochrome/crocochrome_test.go
+++ b/internal/crocochrome/crocochrome_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/grafana/crocochrome/internal/crocochrome"
 	"github.com/grafana/crocochrome/internal/testutil"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestCrocochrome(t *testing.T) {
@@ -224,5 +226,58 @@ func TestCrocochrome(t *testing.T) {
 				t.Fatalf("expected sessions list to be empty, not %v", list)
 			}
 		})
+	})
+
+	t.Run("increments OOM kill counter when cgroup reports a kill during session", func(t *testing.T) {
+		t.Parallel()
+
+		// Write a cgroup file starting at oom_kill=0. We'll bump it to 1 while the session
+		// is live to simulate the OOM killer firing during the session.
+		cgroupFile := writeTempFile(t, "oom_kill 0\n")
+
+		hb := testutil.NewHeartbeat(t)
+		port := testutil.HTTPInfo(t, testutil.ChromiumVersionHandler)
+
+		reg := prometheus.NewRegistry()
+		cc := crocochrome.New(
+			slog.New(slog.NewTextHandler(os.Stderr, nil)),
+			crocochrome.Options{
+				ChromiumPath:           hb.Path,
+				ChromiumPort:           port,
+				CgroupMemoryEventsPath: cgroupFile,
+				Registry:               reg,
+			},
+		)
+
+		sess, err := cc.Create(crocochrome.CheckInfo{})
+		if err != nil {
+			t.Fatalf("creating session: %v", err)
+		}
+
+		// Simulate OOM kill by incrementing the cgroup counter while the session is running.
+		if err := os.WriteFile(cgroupFile, []byte("oom_kill 1\n"), 0o600); err != nil {
+			t.Fatalf("updating cgroup file: %v", err)
+		}
+
+		cc.Delete(sess.ID)
+		cc.Wait()
+
+		got, err := promtestutil.GatherAndCount(reg, "sm_crocochrome_chromium_oom_kills_total")
+		if err != nil {
+			t.Fatalf("gathering metrics: %v", err)
+		}
+
+		if got == 0 {
+			t.Fatal("expected sm_crocochrome_chromium_oom_kills_total to be present in registry")
+		}
+
+		const wantMetric = `# HELP sm_crocochrome_chromium_oom_kills_total Total number of times the kernel OOM-killer fired within the container cgroup during a Chromium session. Incremented when the oom_kill counter in the cgroup memory events file increases between session start and session end.
+# TYPE sm_crocochrome_chromium_oom_kills_total counter
+sm_crocochrome_chromium_oom_kills_total 1
+`
+		if err := promtestutil.GatherAndCompare(reg, strings.NewReader(wantMetric),
+			"sm_crocochrome_chromium_oom_kills_total"); err != nil {
+			t.Errorf("OOM kill counter mismatch: %v", err)
+		}
 	})
 }

--- a/internal/crocochrome/crocochrome_test.go
+++ b/internal/crocochrome/crocochrome_test.go
@@ -280,4 +280,75 @@ sm_crocochrome_chromium_oom_kills_total 1
 			t.Errorf("OOM kill counter mismatch: %v", err)
 		}
 	})
+
+	t.Run("logs per-process metrics and session summary on Delete", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		hb := testutil.NewHeartbeat(t)
+		port := testutil.HTTPInfo(t, testutil.ChromiumVersionHandler)
+
+		// Set up a fake cgroup dir and proc dir so process metrics can be collected.
+		cgroupDir := t.TempDir()
+		procRoot := t.TempDir()
+
+		writeFile := func(path, content string) {
+			t.Helper()
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		eventsPath := cgroupDir + "/memory.events"
+		writeFile(eventsPath, "oom_kill 0\n")
+		writeFile(cgroupDir+"/cgroup.procs", "9001\n")
+		writeFile(cgroupDir+"/memory.current", "314572800\n") // 300 MiB
+
+		if err := os.MkdirAll(procRoot+"/9001", 0755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(procRoot+"/9001/cmdline", "/usr/lib/chromium/chromium\x00--no-sandbox\x00")
+		writeFile(procRoot+"/9001/status", "VmHWM:\t 250000 kB\nVmRSS:\t 200000 kB\n")
+
+		cc := crocochrome.New(logger, crocochrome.Options{
+			ChromiumPath:           hb.Path,
+			ChromiumPort:           port,
+			EnableProcessMetrics:   true,
+			CgroupMemoryEventsPath: eventsPath,
+			ProcFSRoot:             procRoot,
+		})
+
+		sess, err := cc.Create(crocochrome.CheckInfo{})
+		if err != nil {
+			t.Fatalf("creating session: %v", err)
+		}
+
+		cc.Delete(sess.ID)
+		cc.Wait()
+
+		logs := buf.String()
+
+		for _, want := range []string{
+			"chromium process memory",
+			"pid=9001",
+			"processType=browser",
+			"peakRSS=256000000", // 250000 kB * 1024
+		} {
+			if !strings.Contains(logs, want) {
+				t.Errorf("expected %q in logs\nLogs:\n%s", want, logs)
+			}
+		}
+
+		for _, want := range []string{
+			"chromium session memory",
+			"cgroupRSS=314572800",
+			"processCount=1",
+		} {
+			if !strings.Contains(logs, want) {
+				t.Errorf("expected %q in logs\nLogs:\n%s", want, logs)
+			}
+		}
+	})
 }

--- a/internal/crocochrome/export_test.go
+++ b/internal/crocochrome/export_test.go
@@ -1,0 +1,9 @@
+// export_test.go exposes unexported symbols for black-box tests in package crocochrome_test.
+// This file is only compiled during `go test`; it does not affect the production binary.
+package crocochrome
+
+// ReadOOMKillCount is the test-visible alias for readOOMKillCount.
+var ReadOOMKillCount func(path string) (uint64, error) = readOOMKillCount
+
+// CgroupV1MemoryOOMControlPath is the test-visible alias for cgroupV1MemoryOOMControlPath.
+var CgroupV1MemoryOOMControlPath func(procSelfCgroupPath string) string = cgroupV1MemoryOOMControlPath

--- a/internal/crocochrome/export_test.go
+++ b/internal/crocochrome/export_test.go
@@ -6,4 +6,4 @@ package crocochrome
 var ReadOOMKillCount func(path string) (uint64, error) = readOOMKillCount
 
 // CgroupV1MemoryOOMControlPath is the test-visible alias for cgroupV1MemoryOOMControlPath.
-var CgroupV1MemoryOOMControlPath func(procSelfCgroupPath string) string = cgroupV1MemoryOOMControlPath
+var CgroupV1MemoryOOMControlPath func(procRoot string) string = cgroupV1MemoryOOMControlPath

--- a/internal/crocochrome/proc.go
+++ b/internal/crocochrome/proc.go
@@ -77,14 +77,27 @@ func chromiumProcessType(pid int, procRoot string) string {
 		return processType
 	}
 
-	// No --type= flag. Classify by binary name to separate the Chromium browser
-	// process from other no-flag co-residents.
+	// No --type= flag. Classify by the basename of the executable (the first
+	// argument, terminated by the first null byte or space) to separate the
+	// Chromium browser process from other no-flag co-residents.
+	//
+	// We use filepath.Base rather than a prefix check because tini may be
+	// invoked with a full path (/sbin/tini, /usr/bin/tini, etc.). A prefix
+	// check would miss those cases and fall through to the "crocochrome"
+	// branch — incorrectly — because tini's cmdline contains "crocochrome"
+	// as an argument.
+	firstArgEnd := strings.IndexAny(raw, "\x00 ")
+	var execBase string
+	if firstArgEnd == -1 {
+		execBase = filepath.Base(raw)
+	} else {
+		execBase = filepath.Base(raw[:firstArgEnd])
+	}
+
 	switch {
 	case strings.Contains(raw, "chrome_crashpad"):
 		return "crashpad"
-	case strings.HasPrefix(raw, "tini"):
-		// tini's cmdline includes its arguments (e.g. "-- /usr/local/bin/crocochrome"),
-		// so it must be matched before the "crocochrome" check below.
+	case execBase == "tini":
 		return "tini"
 	case strings.Contains(raw, "crocochrome"):
 		return "crocochrome"

--- a/internal/crocochrome/proc.go
+++ b/internal/crocochrome/proc.go
@@ -1,0 +1,182 @@
+package crocochrome
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// processInfo holds OS-level information for a single process in the Chromium process tree.
+type processInfo struct {
+	PID     int
+	Type    string // "browser", "renderer", "gpu-process", "network-service", "utility", "unknown"
+	RSS     int64  // current resident set size in bytes (point-in-time at collection)
+	PeakRSS int64  // peak resident set size since process start (VmHWM), in bytes
+}
+
+// cgroupProcsPath derives the cgroup.procs file path from the memory events file path.
+// Both cgroupsv1 and cgroupsv2 keep cgroup.procs alongside the memory event files.
+func cgroupProcsPath(eventsPath string) string {
+	return filepath.Join(filepath.Dir(eventsPath), "cgroup.procs")
+}
+
+// cgroupMemoryCurrentPath derives the total memory usage file path from the events file path.
+// For cgroupsv2 (memory.events) this is memory.current; for cgroupsv1 (memory.oom_control)
+// this is memory.usage_in_bytes.
+func cgroupMemoryCurrentPath(eventsPath string) string {
+	dir := filepath.Dir(eventsPath)
+	if filepath.Base(eventsPath) == "memory.events" {
+		return filepath.Join(dir, "memory.current")
+	}
+	return filepath.Join(dir, "memory.usage_in_bytes")
+}
+
+// chromiumProcessType reads /proc/<pid>/cmdline and returns the Chromium process type.
+// Returns "browser" only for the main Chromium browser process (no --type= flag and no
+// other known binary signature). Returns "unknown" if cmdline cannot be read.
+//
+// Chromium uses two distinct cmdline formats on Linux:
+//
+//   - Processes launched via exec (browser, crashpad): argv entries are null-byte separated,
+//     matching the standard Linux /proc/<pid>/cmdline layout.
+//
+//   - Processes spawned via the Zygote (renderers, GPU, utility): after fork, Chromium calls
+//     SetProcessTitleFromCommandLine() which rewrites the argv region as a single
+//     space-separated string with only a trailing null byte. Null-splitting these produces
+//     one giant token, so --type= is found as a raw substring instead.
+//
+// Processes without a --type= flag are further classified by their binary/cmdline content
+// to distinguish the Chromium browser process from co-resident processes (tini,
+// crocochrome, crashpad handlers) that also lack a --type= argument.
+// Note: tini's cmdline includes "crocochrome" as an argument, so it must be checked first.
+func chromiumProcessType(pid int, procRoot string) string {
+	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return "unknown"
+	}
+
+	raw := string(data)
+
+	// Find --type= as a raw substring and extract the value terminated by the next
+	// space, null byte, or end of string.
+	if idx := strings.Index(raw, "--type="); idx != -1 {
+		rest := raw[idx+len("--type="):]
+		var processType string
+		if end := strings.IndexAny(rest, " \x00"); end != -1 {
+			processType = rest[:end]
+		} else {
+			processType = rest
+		}
+
+		// Distinguish the network service from generic utility processes.
+		if processType == "utility" && strings.Contains(raw, "network.mojom.NetworkService") {
+			return "network-service"
+		}
+		return processType
+	}
+
+	// No --type= flag. Classify by binary name to separate the Chromium browser
+	// process from other no-flag co-residents.
+	switch {
+	case strings.Contains(raw, "chrome_crashpad"):
+		return "crashpad"
+	case strings.HasPrefix(raw, "tini"):
+		// tini's cmdline includes its arguments (e.g. "-- /usr/local/bin/crocochrome"),
+		// so it must be matched before the "crocochrome" check below.
+		return "tini"
+	case strings.Contains(raw, "crocochrome"):
+		return "crocochrome"
+	default:
+		return "browser"
+	}
+}
+
+// processMemoryStats reads /proc/<pid>/status and returns the current RSS (VmRSS) and
+// peak RSS (VmHWM) in bytes. Both fields are parsed in a single pass; no extra syscall
+// is needed. Values are in KiB in the status file; this function converts to bytes.
+//
+// VmHWM (high-water mark) is the peak RSS since the process started. Since Chromium
+// subprocesses are spawned fresh per session, VmHWM is effectively the session peak.
+func processMemoryStats(pid int, procRoot string) (rss, peakRSS int64, _ error) {
+	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "status"))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		switch {
+		case strings.HasPrefix(line, "VmRSS:"):
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				return 0, 0, fmt.Errorf("unexpected VmRSS line format: %q", line)
+			}
+			kb, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				return 0, 0, fmt.Errorf("parsing VmRSS value %q: %w", fields[1], err)
+			}
+			rss = kb * 1024
+		case strings.HasPrefix(line, "VmHWM:"):
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				return 0, 0, fmt.Errorf("unexpected VmHWM line format: %q", line)
+			}
+			kb, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				return 0, 0, fmt.Errorf("parsing VmHWM value %q: %w", fields[1], err)
+			}
+			peakRSS = kb * 1024
+		}
+	}
+
+	if rss == 0 && peakRSS == 0 {
+		return 0, 0, fmt.Errorf("VmRSS/VmHWM not found in /proc/%d/status", pid)
+	}
+
+	return rss, peakRSS, nil
+}
+
+// collectProcessMetrics walks cgroup.procs and returns per-process info plus the total
+// cgroup RSS from memory.current (cgroupsv2) or memory.usage_in_bytes (cgroupsv1).
+// Processes that exit between enumeration and reading are silently skipped — this is
+// an expected race condition when collecting at session teardown.
+func collectProcessMetrics(cgroupEventsPath, procRoot string) (processes []processInfo, cgroupRSS int64, _ error) {
+	procsData, err := os.ReadFile(cgroupProcsPath(cgroupEventsPath))
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading cgroup.procs: %w", err)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(procsData)), "\n") {
+		if line == "" {
+			continue
+		}
+		pid, err := strconv.Atoi(line)
+		if err != nil {
+			continue
+		}
+		rss, peakRSS, err := processMemoryStats(pid, procRoot)
+		if err != nil {
+			continue // process likely exited between enumeration and read; skip silently
+		}
+		processes = append(processes, processInfo{
+			PID:     pid,
+			Type:    chromiumProcessType(pid, procRoot),
+			RSS:     rss,
+			PeakRSS: peakRSS,
+		})
+	}
+
+	// Read the kernel-maintained total. More accurate than summing per-process VmRSS:
+	// the cgroup counter includes kernel memory and avoids shared-page double-counting.
+	currentData, err := os.ReadFile(cgroupMemoryCurrentPath(cgroupEventsPath))
+	if err != nil {
+		return processes, 0, fmt.Errorf("reading cgroup memory current: %w", err)
+	}
+	cgroupRSS, err = strconv.ParseInt(strings.TrimSpace(string(currentData)), 10, 64)
+	if err != nil {
+		return processes, 0, fmt.Errorf("parsing cgroup memory current: %w", err)
+	}
+
+	return processes, cgroupRSS, nil
+}

--- a/internal/crocochrome/proc.go
+++ b/internal/crocochrome/proc.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs"
 )
 
 // processInfo holds OS-level information for a single process in the Chromium process tree.
@@ -106,48 +108,32 @@ func chromiumProcessType(pid int, procRoot string) string {
 	}
 }
 
-// processMemoryStats reads /proc/<pid>/status and returns the current RSS (VmRSS) and
-// peak RSS (VmHWM) in bytes. Both fields are parsed in a single pass; no extra syscall
-// is needed. Values are in KiB in the status file; this function converts to bytes.
+// processMemoryStats returns the current RSS (VmRSS) and peak RSS (VmHWM) in bytes for
+// the given pid, parsed from /proc/<pid>/status via prometheus/procfs.
 //
 // VmHWM (high-water mark) is the peak RSS since the process started. Since Chromium
 // subprocesses are spawned fresh per session, VmHWM is effectively the session peak.
 func processMemoryStats(pid int, procRoot string) (rss, peakRSS int64, _ error) {
-	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "status"))
+	fs, err := procfs.NewFS(procRoot)
+	if err != nil {
+		return 0, 0, fmt.Errorf("opening procfs at %q: %w", procRoot, err)
+	}
+
+	p, err := fs.Proc(pid)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	for _, line := range strings.Split(string(data), "\n") {
-		switch {
-		case strings.HasPrefix(line, "VmRSS:"):
-			fields := strings.Fields(line)
-			if len(fields) < 2 {
-				return 0, 0, fmt.Errorf("unexpected VmRSS line format: %q", line)
-			}
-			kb, err := strconv.ParseInt(fields[1], 10, 64)
-			if err != nil {
-				return 0, 0, fmt.Errorf("parsing VmRSS value %q: %w", fields[1], err)
-			}
-			rss = kb * 1024
-		case strings.HasPrefix(line, "VmHWM:"):
-			fields := strings.Fields(line)
-			if len(fields) < 2 {
-				return 0, 0, fmt.Errorf("unexpected VmHWM line format: %q", line)
-			}
-			kb, err := strconv.ParseInt(fields[1], 10, 64)
-			if err != nil {
-				return 0, 0, fmt.Errorf("parsing VmHWM value %q: %w", fields[1], err)
-			}
-			peakRSS = kb * 1024
-		}
+	st, err := p.NewStatus()
+	if err != nil {
+		return 0, 0, err
 	}
 
-	if rss == 0 && peakRSS == 0 {
+	if st.VmRSS == 0 && st.VmHWM == 0 {
 		return 0, 0, fmt.Errorf("VmRSS/VmHWM not found in /proc/%d/status", pid)
 	}
 
-	return rss, peakRSS, nil
+	return int64(st.VmRSS), int64(st.VmHWM), nil
 }
 
 // collectProcessMetrics walks cgroup.procs and returns per-process info plus the total

--- a/internal/crocochrome/proc_test.go
+++ b/internal/crocochrome/proc_test.go
@@ -72,8 +72,13 @@ func TestChromiumProcessType(t *testing.T) {
 			want:    "browser",
 		},
 		{
-			name:    "tini supervisor",
+			name:    "tini supervisor (bare name)",
 			cmdline: "tini\x00--\x00/usr/local/bin/crocochrome\x00-cdp-metrics\x00",
+			want:    "tini",
+		},
+		{
+			name:    "tini supervisor (full path — must not misclassify as crocochrome)",
+			cmdline: "/sbin/tini\x00--\x00/usr/local/bin/crocochrome\x00-cdp-metrics\x00",
 			want:    "tini",
 		},
 		{

--- a/internal/crocochrome/proc_test.go
+++ b/internal/crocochrome/proc_test.go
@@ -1,0 +1,398 @@
+package crocochrome
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCgroupProcsPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		eventsPath string
+		want       string
+	}{
+		{
+			eventsPath: "/sys/fs/cgroup/kubepods/pod123/memory.events",
+			want:       "/sys/fs/cgroup/kubepods/pod123/cgroup.procs",
+		},
+		{
+			eventsPath: "/sys/fs/cgroup/memory/kubepods/pod123/memory.oom_control",
+			want:       "/sys/fs/cgroup/memory/kubepods/pod123/cgroup.procs",
+		},
+	}
+
+	for _, tc := range cases {
+		got := cgroupProcsPath(tc.eventsPath)
+		if got != tc.want {
+			t.Errorf("cgroupProcsPath(%q) = %q, want %q", tc.eventsPath, got, tc.want)
+		}
+	}
+}
+
+func TestCgroupMemoryCurrentPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		eventsPath string
+		want       string
+	}{
+		{
+			eventsPath: "/sys/fs/cgroup/kubepods/pod123/memory.events",
+			want:       "/sys/fs/cgroup/kubepods/pod123/memory.current",
+		},
+		{
+			eventsPath: "/sys/fs/cgroup/memory/kubepods/pod123/memory.oom_control",
+			want:       "/sys/fs/cgroup/memory/kubepods/pod123/memory.usage_in_bytes",
+		},
+	}
+
+	for _, tc := range cases {
+		got := cgroupMemoryCurrentPath(tc.eventsPath)
+		if got != tc.want {
+			t.Errorf("cgroupMemoryCurrentPath(%q) = %q, want %q", tc.eventsPath, got, tc.want)
+		}
+	}
+}
+
+func TestChromiumProcessType(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		cmdline string // null-separated args
+		want    string
+	}{
+		// Null-byte separated: standard exec'd processes (browser, crashpad).
+		{
+			name:    "chromium browser process (no --type flag, null-separated)",
+			cmdline: "/usr/lib/chromium/chromium\x00--no-sandbox\x00--headless\x00",
+			want:    "browser",
+		},
+		{
+			name:    "tini supervisor",
+			cmdline: "tini\x00--\x00/usr/local/bin/crocochrome\x00-cdp-metrics\x00",
+			want:    "tini",
+		},
+		{
+			name:    "crocochrome process",
+			cmdline: "/usr/local/bin/crocochrome\x00-cdp-metrics\x00",
+			want:    "crocochrome",
+		},
+		{
+			name:    "chrome crashpad handler",
+			cmdline: "/usr/lib/chromium/chrome_crashpad_handler\x00--monitor-self\x00--database=/tmp/crashreports\x00",
+			want:    "crashpad",
+		},
+		{
+			name:    "renderer process (null-separated)",
+			cmdline: "/usr/bin/chromium\x00--type=renderer\x00--no-sandbox\x00",
+			want:    "renderer",
+		},
+		{
+			name:    "GPU process (null-separated)",
+			cmdline: "/usr/bin/chromium\x00--type=gpu-process\x00",
+			want:    "gpu-process",
+		},
+		{
+			name:    "network service utility (null-separated)",
+			cmdline: "/usr/bin/chromium\x00--type=utility\x00--utility-sub-type=network.mojom.NetworkService\x00",
+			want:    "network-service",
+		},
+		{
+			name:    "generic utility (null-separated)",
+			cmdline: "/usr/bin/chromium\x00--type=utility\x00--utility-sub-type=audio.mojom.AudioService\x00",
+			want:    "utility",
+		},
+		// Space-separated: Zygote-forked processes (renderer, GPU, utility, zygote).
+		// Chromium's SetProcessTitleFromCommandLine() rewrites argv as a single
+		// space-separated string, removing null bytes.
+		{
+			name:    "renderer process (space-separated, Zygote-forked)",
+			cmdline: "/usr/lib/chromium/chromium --type=renderer --no-sandbox --headless --crashpad-handler-pid=100",
+			want:    "renderer",
+		},
+		{
+			name:    "GPU process (space-separated, Zygote-forked)",
+			cmdline: "/usr/lib/chromium/chromium --type=gpu-process --no-sandbox --use-angle=swiftshader-webgl",
+			want:    "gpu-process",
+		},
+		{
+			name:    "zygote process (space-separated)",
+			cmdline: "/usr/lib/chromium/chromium --type=zygote --no-zygote-sandbox --no-sandbox",
+			want:    "zygote",
+		},
+		{
+			name:    "network service utility (space-separated, Zygote-forked)",
+			cmdline: "/usr/lib/chromium/chromium --type=utility --utility-sub-type=network.mojom.NetworkService --no-sandbox",
+			want:    "network-service",
+		},
+		{
+			name:    "storage service utility (space-separated, Zygote-forked)",
+			cmdline: "/usr/lib/chromium/chromium --type=utility --utility-sub-type=storage.mojom.StorageService --no-sandbox",
+			want:    "utility",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			procRoot := t.TempDir()
+			pid := 1234
+			pidDir := filepath.Join(procRoot, fmt.Sprintf("%d", pid))
+			if err := os.MkdirAll(pidDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte(tc.cmdline), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			got := chromiumProcessType(pid, procRoot)
+			if got != tc.want {
+				t.Errorf("chromiumProcessType() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChromiumProcessType_missingCmdline(t *testing.T) {
+	t.Parallel()
+
+	procRoot := t.TempDir()
+	got := chromiumProcessType(9999, procRoot)
+	if got != "unknown" {
+		t.Errorf("chromiumProcessType() with missing cmdline = %q, want %q", got, "unknown")
+	}
+}
+
+func TestProcessMemoryStats(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		status      string
+		wantRSS     int64
+		wantPeakRSS int64
+		wantErr     bool
+	}{
+		{
+			name: "parses VmRSS and VmHWM correctly",
+			status: `Name:	chromium
+VmPeak:	 500000 kB
+VmHWM:	 200000 kB
+VmSize:	 400000 kB
+VmRSS:	 153600 kB
+VmData:	 200000 kB
+`,
+			wantRSS:     153600 * 1024,
+			wantPeakRSS: 200000 * 1024,
+		},
+		{
+			name: "peak equals current when process hasn't freed memory",
+			status: `Name:	chromium
+VmHWM:	 153600 kB
+VmRSS:	 153600 kB
+`,
+			wantRSS:     153600 * 1024,
+			wantPeakRSS: 153600 * 1024,
+		},
+		{
+			name:    "returns error when both VmRSS and VmHWM absent",
+			status:  "Name:\tchromium\nVmSize:\t100 kB\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			procRoot := t.TempDir()
+			pid := 42
+			pidDir := filepath.Join(procRoot, fmt.Sprintf("%d", pid))
+			if err := os.MkdirAll(pidDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(pidDir, "status"), []byte(tc.status), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			gotRSS, gotPeak, err := processMemoryStats(pid, procRoot)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotRSS != tc.wantRSS {
+				t.Errorf("rss = %d, want %d", gotRSS, tc.wantRSS)
+			}
+			if gotPeak != tc.wantPeakRSS {
+				t.Errorf("peakRSS = %d, want %d", gotPeak, tc.wantPeakRSS)
+			}
+		})
+	}
+}
+
+func TestCollectProcessMetrics(t *testing.T) {
+	t.Parallel()
+
+	cgroupDir := t.TempDir()
+	procRoot := t.TempDir()
+
+	// Write cgroup files (cgroupsv2 layout).
+	eventsPath := filepath.Join(cgroupDir, "memory.events")
+	if err := os.WriteFile(eventsPath, []byte("oom_kill 0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cgroupDir, "cgroup.procs"), []byte("100\n200\n300\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("524288000\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write fake /proc entries.
+	writeProc := func(pid int, cmdline, vmRSSLine, vmHWMLine string) {
+		t.Helper()
+		dir := filepath.Join(procRoot, fmt.Sprintf("%d", pid))
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "cmdline"), []byte(cmdline), 0644); err != nil {
+			t.Fatal(err)
+		}
+		status := fmt.Sprintf("Name:\tchromium\n%s\n%s\n", vmHWMLine, vmRSSLine)
+		if err := os.WriteFile(filepath.Join(dir, "status"), []byte(status), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeProc(100, "/usr/bin/chromium\x00--no-sandbox\x00", "VmRSS:\t 150000 kB", "VmHWM:\t 180000 kB")       // browser
+	writeProc(200, "/usr/bin/chromium\x00--type=renderer\x00", "VmRSS:\t 300000 kB", "VmHWM:\t 400000 kB")    // renderer
+	writeProc(300, "/usr/bin/chromium\x00--type=gpu-process\x00", "VmRSS:\t 200000 kB", "VmHWM:\t 220000 kB") // GPU
+
+	processes, cgroupRSS, err := collectProcessMetrics(eventsPath, procRoot)
+	if err != nil {
+		t.Fatalf("collectProcessMetrics() error: %v", err)
+	}
+
+	if cgroupRSS != 524288000 {
+		t.Errorf("cgroupRSS = %d, want 524288000", cgroupRSS)
+	}
+
+	if len(processes) != 3 {
+		t.Fatalf("got %d processes, want 3", len(processes))
+	}
+
+	byPID := make(map[int]processInfo)
+	for _, p := range processes {
+		byPID[p.PID] = p
+	}
+
+	cases := []struct {
+		pid         int
+		wantType    string
+		wantRSS     int64
+		wantPeakRSS int64
+	}{
+		{100, "browser", 150000 * 1024, 180000 * 1024},
+		{200, "renderer", 300000 * 1024, 400000 * 1024},
+		{300, "gpu-process", 200000 * 1024, 220000 * 1024},
+	}
+
+	for _, tc := range cases {
+		p, ok := byPID[tc.pid]
+		if !ok {
+			t.Errorf("PID %d not found in results", tc.pid)
+			continue
+		}
+		if p.Type != tc.wantType {
+			t.Errorf("PID %d: type = %q, want %q", tc.pid, p.Type, tc.wantType)
+		}
+		if p.RSS != tc.wantRSS {
+			t.Errorf("PID %d: RSS = %d, want %d", tc.pid, p.RSS, tc.wantRSS)
+		}
+		if p.PeakRSS != tc.wantPeakRSS {
+			t.Errorf("PID %d: PeakRSS = %d, want %d", tc.pid, p.PeakRSS, tc.wantPeakRSS)
+		}
+	}
+}
+
+func TestCollectProcessMetrics_skipsExitedProcesses(t *testing.T) {
+	t.Parallel()
+
+	cgroupDir := t.TempDir()
+	procRoot := t.TempDir()
+
+	eventsPath := filepath.Join(cgroupDir, "memory.events")
+	if err := os.WriteFile(eventsPath, []byte("oom_kill 0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// cgroup.procs lists PID 999 which has no /proc entry (already exited).
+	if err := os.WriteFile(filepath.Join(cgroupDir, "cgroup.procs"), []byte("999\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("1048576\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	processes, cgroupRSS, err := collectProcessMetrics(eventsPath, procRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(processes) != 0 {
+		t.Errorf("expected 0 processes (all exited), got %d", len(processes))
+	}
+	if cgroupRSS != 1048576 {
+		t.Errorf("cgroupRSS = %d, want 1048576", cgroupRSS)
+	}
+}
+
+func TestCollectProcessMetrics_cgroupsv1Layout(t *testing.T) {
+	t.Parallel()
+
+	cgroupDir := t.TempDir()
+	procRoot := t.TempDir()
+
+	// cgroupsv1 layout: memory.oom_control instead of memory.events.
+	eventsPath := filepath.Join(cgroupDir, "memory.oom_control")
+	if err := os.WriteFile(eventsPath, []byte("oom_kill 0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cgroupDir, "cgroup.procs"), []byte("101\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// cgroupsv1 uses memory.usage_in_bytes.
+	if err := os.WriteFile(filepath.Join(cgroupDir, "memory.usage_in_bytes"), []byte("262144000\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pidDir := filepath.Join(procRoot, "101")
+	if err := os.MkdirAll(pidDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("/usr/bin/chromium\x00"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "status"), []byte("VmHWM:\t 100000 kB\nVmRSS:\t 100000 kB\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	processes, cgroupRSS, err := collectProcessMetrics(eventsPath, procRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cgroupRSS != 262144000 {
+		t.Errorf("cgroupRSS = %d, want 262144000", cgroupRSS)
+	}
+	if len(processes) != 1 || processes[0].Type != "browser" {
+		t.Errorf("unexpected processes: %+v", processes)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -83,6 +83,11 @@ type SupervisorMetrics struct {
 	SessionDuration    prometheus.Histogram
 	ChromiumExecutions *prometheus.CounterVec
 	ChromiumResources  *prometheus.HistogramVec
+	// OOMKills counts the number of times the kernel OOM-killer fired within the container's
+	// cgroup during a Chromium session. A non-zero value indicates that Chromium's multi-process
+	// tree (renderer, GPU process, etc.) exceeded the container memory limit and had one or more
+	// processes killed, even if crocochrome itself survived.
+	OOMKills prometheus.Counter
 }
 
 // Supervisor registers and returns handlers for metrics used by the supervisor.
@@ -125,11 +130,22 @@ func Supervisor(reg prometheus.Registerer) *SupervisorMetrics {
 			},
 			[]string{Resource},
 		),
+		OOMKills: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: metricNs,
+				Subsystem: metricSubsystemCrocochrome,
+				Name:      "chromium_oom_kills_total",
+				Help: "Total number of times the kernel OOM-killer fired within the container cgroup " +
+					"during a Chromium session. Incremented when the oom_kill counter in the cgroup " +
+					"memory events file increases between session start and session end.",
+			},
+		),
 	}
 
 	reg.MustRegister(m.SessionDuration)
 	reg.MustRegister(m.ChromiumExecutions)
 	reg.MustRegister(m.ChromiumResources)
+	reg.MustRegister(m.OOMKills)
 
 	return m
 }


### PR DESCRIPTION
## Summary

The existing `rUsage` we've used only captures the browser-process RSS (~230 MiB), missing renderer, GPU, and network service sub-processes that collectively consumed 1.8–2+ GiB and triggered OOM kills.

This PR uses Linux kernel interfaces only — no network calls, no external dependencies — and adds negligible overhead to \`DELETE /sessions\`. It gives observability into the multiple processes comprising a Chromium browser session using these interfaces.

The subsequent PR instruments CDP to get the in-process utilization from chromium.

---

### 1. OOM kill detection via cgroup \`oom_kill\` counter

`launch()` samples the cgroup `oom_kill` counter before and after `cmd.Run()`. A positive delta increments `sm_crocochrome_chromium_oom_kills_total`, distinguishing kernel OOM kills from the `SIGKILL` crocochrome itself sends at teardown — both produce `signal: killed` in `ProcessState`, making them previously identical.

Supports cgroupsv2 (`memory.events`) and cgroupsv1 (`memory.oom_control`), auto-detected at startup. My understanding is that we are on `cgroupsv2`, but this is an additional stopgap.

### 2. Per-process RSS and session memory summary

When `--process-metrics` is enabled, `Delete()` walks `cgroup.procs` before sending SIGKILL and emits:

**Per-process entries** — one per OS process in the container cgroup:

    msg="chromium process memory" processType=browser        rss=157286400 peakRSS=220000000
    msg="chromium process memory" processType=renderer       rss=367001600 peakRSS=410000000
    msg="chromium process memory" processType=gpu-process    rss=209715200 peakRSS=230000000
    msg="chromium process memory" processType=network-service rss=41943040 peakRSS=41943040

**Session summary** — cgroup-level total (deduplicates shared pages; do not sum per-process `rss`):

    msg="chromium session memory" cgroupRSS=838860800 processCount=13

All entries carry `sessionID`, `id` (checkID), `tenantID`, `regionID` for per-check correlation in Loki.

### 3. Fix: `wg.Done()` placement for correct `Wait()` semantics

`wg.Done()` was called in the `context.AfterFunc` callback, meaning `Supervisor.Wait()` could return before `launch()` finished OOM sampling, tmpdir cleanup, or metric emission. Moved to the goroutine that calls `launch()` so `Wait()` correctly blocks until all post-session work is complete.

---

## Enabling

```
crocochrome --process-metrics
```

Deploying without this flag is a strict no-op.

## Changes

| File | Change |
|---|---|
| \`internal/crocochrome/cgroup.go\` | cgroupsv1/v2 OOM kill counter reader; path auto-detection |
| \`internal/crocochrome/cgroup_test.go\` | Unit tests for both cgroup file formats |
| \`internal/crocochrome/export_test.go\` | Standard Go test-export pattern for unexported cgroup symbols |
| \`internal/crocochrome/proc.go\` | Per-process RSS collection: \`cgroup.procs\` walk, \`VmRSS\`/\`VmHWM\` parsing, process type identification from \`/proc/<pid>/cmdline\` |
| \`internal/crocochrome/proc_test.go\` | Unit tests including both null-byte and space-separated cmdline formats (Chromium Zygote-forked processes use space separators) |
| \`internal/crocochrome/crocochrome.go\` | \`wg.Done()\` fix; OOM sampling in \`launch()\`; \`Delete()\` process wiring; \`EnableProcessMetrics\`/\`ProcFSRoot\` options |
| \`internal/metrics/metrics.go\` | \`sm_crocochrome_chromium_oom_kills_total\` counter |
| \`cmd/crocochrome/main.go\` | \`-process-metrics\` flag |
| \`doc/chromium-observability.md\` | Operator guide: process memory entries, session summary, OOM counter, Loki/PromQL queries, caveats |

## Caveats

- **Summing per-process \`rss\`** — `VmRss` includes a shared component (`RssShMem`) - be aware that summing it across processes can double-count these portions; `cgroupRSS` is the accurate total, but also includes `tini` and `crocochrome` (which should be fairly stable).
- **`rss` is a teardown snapshot** — use `peakRSS` (`VmHWM`) for the session high-water mark.
- **OOM-killed sessions** — `cgroupRSS` at teardown shows post-kill state; the OOM counter is the primary signal.

A follow-up PR adds CDP-based renderer metrics (`Performance.getMetrics`) via `--cdp-metrics`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session teardown and process lifecycle paths (`launch`/`Delete`) and adds new file-system reads from cgroup/procfs that could vary across environments, though behavior is mostly opt-in and failures are handled best-effort.
> 
> **Overview**
> Adds **Chromium memory observability** via Linux cgroup/procfs accounting. The supervisor now samples the cgroup `oom_kill` counter around each Chromium run and exports a new Prometheus counter `sm_crocochrome_chromium_oom_kills_total` when kills occur.
> 
> Introduces an opt-in `-process-metrics` flag that, on session `Delete`, walks `cgroup.procs` and logs per-process `rss`/`peakRSS` plus a session-level `cgroupRSS` summary (with process type classification from `/proc/<pid>/cmdline`). Teardown semantics are tightened by moving `wg.Done()` to the `launch()` goroutine and making session removal+cancel atomic (`takeSession`) to reduce races; docs and tests are added/updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e682aaaf2ed25c51080c11ef0c4f8664fc0cfbb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->