### PR TITLE
use prometheus procfs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/procfs v0.16.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	golang.org/x/sync v0.20.0
 )
@@ -52,7 +53,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
-	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect

--- a/internal/crocochrome/cgroup.go
+++ b/internal/crocochrome/cgroup.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs"
 )
 
 const (
@@ -18,9 +20,6 @@ const (
 	// cgroupV1OOMControl is the path template for the cgroups v1 memory OOM control file.
 	// The actual path is constructed by reading /proc/self/cgroup.
 	cgroupV1OOMControl = "/sys/fs/cgroup/memory%s/memory.oom_control"
-
-	// procSelfCgroup is the standard path for the calling process's cgroup memberships.
-	procSelfCgroup = "/proc/self/cgroup"
 )
 
 // detectCgroupMemoryEventsPath returns the path to the file that contains the cgroup OOM kill
@@ -31,36 +30,37 @@ const (
 //  1. cgroupsv2: /sys/fs/cgroup/memory.events
 //  2. cgroupsv1: /sys/fs/cgroup/memory/<hierarchy-path>/memory.oom_control (derived from
 //     /proc/self/cgroup)
-func detectCgroupMemoryEventsPath() string {
+func detectCgroupMemoryEventsPath(procRoot string) string {
 	if _, err := os.Stat(cgroupV2MemoryEvents); err == nil {
 		return cgroupV2MemoryEvents
 	}
 
-	return cgroupV1MemoryOOMControlPath(procSelfCgroup)
+	return cgroupV1MemoryOOMControlPath(procRoot)
 }
 
-// cgroupV1MemoryOOMControlPath reads procSelfCgroupPath (/proc/self/cgroup) and returns the
-// memory.oom_control path for the memory controller hierarchy, or "" if it cannot be found.
-func cgroupV1MemoryOOMControlPath(procSelfCgroupPath string) string {
-	f, err := os.Open(procSelfCgroupPath)
+// cgroupV1MemoryOOMControlPath resolves the calling process's cgroupv1 memory hierarchy
+// via prometheus/procfs and returns the memory.oom_control path for that hierarchy, or
+// "" if the memory controller is not found or procfs cannot be opened.
+func cgroupV1MemoryOOMControlPath(procRoot string) string {
+	fs, err := procfs.NewFS(procRoot)
 	if err != nil {
 		return ""
 	}
-	defer f.Close() //nolint:errcheck
 
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		// Format: <hierarchy-id>:<controller-list>:<cgroup-path>
-		// e.g.   12:memory:/kubepods/besteffort/pod.../container-id
-		parts := strings.SplitN(scanner.Text(), ":", 3)
-		if len(parts) != 3 {
-			continue
-		}
+	self, err := fs.Self()
+	if err != nil {
+		return ""
+	}
 
-		controllers := strings.Split(parts[1], ",")
-		for _, c := range controllers {
+	cgs, err := self.Cgroups()
+	if err != nil {
+		return ""
+	}
+
+	for _, cg := range cgs {
+		for _, c := range cg.Controllers {
 			if c == "memory" {
-				return fmt.Sprintf(cgroupV1OOMControl, parts[2])
+				return fmt.Sprintf(cgroupV1OOMControl, cg.Path)
 			}
 		}
 	}

--- a/internal/crocochrome/cgroup_test.go
+++ b/internal/crocochrome/cgroup_test.go
@@ -109,11 +109,11 @@ func TestCgroupV1MemoryOOMControlPath(t *testing.T) {
 	t.Run("extracts memory controller path", func(t *testing.T) {
 		t.Parallel()
 
-		f := writeTempFile(t, `11:blkio:/kubepods
+		root := newFakeProcFS(t, `11:blkio:/kubepods
 12:memory:/kubepods/besteffort/podabc123/container456
 13:cpu,cpuacct:/kubepods
 `)
-		got := crocochrome.CgroupV1MemoryOOMControlPath(f)
+		got := crocochrome.CgroupV1MemoryOOMControlPath(root)
 		want := "/sys/fs/cgroup/memory/kubepods/besteffort/podabc123/container456/memory.oom_control"
 
 		if got != want {
@@ -124,21 +124,44 @@ func TestCgroupV1MemoryOOMControlPath(t *testing.T) {
 	t.Run("returns empty string when memory controller is absent", func(t *testing.T) {
 		t.Parallel()
 
-		f := writeTempFile(t, `11:blkio:/kubepods
+		root := newFakeProcFS(t, `11:blkio:/kubepods
 13:cpu,cpuacct:/kubepods
 `)
-		if got := crocochrome.CgroupV1MemoryOOMControlPath(f); got != "" {
+		if got := crocochrome.CgroupV1MemoryOOMControlPath(root); got != "" {
 			t.Fatalf("expected empty string, got %q", got)
 		}
 	})
 
-	t.Run("returns empty string for non-existent file", func(t *testing.T) {
+	t.Run("returns empty string for non-existent procfs root", func(t *testing.T) {
 		t.Parallel()
 
 		if got := crocochrome.CgroupV1MemoryOOMControlPath("/does/not/exist"); got != "" {
 			t.Fatalf("expected empty string, got %q", got)
 		}
 	})
+}
+
+// newFakeProcFS creates a tempdir that procfs.NewFS will accept as a procfs root,
+// containing a single pid directory with the given /proc/<pid>/cgroup contents and
+// a "self" symlink pointing at it. Returns the root path.
+func newFakeProcFS(t *testing.T, cgroupContents string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	const pid = "1234"
+
+	pidDir := filepath.Join(root, pid)
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatalf("creating pid dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "cgroup"), []byte(cgroupContents), 0o600); err != nil {
+		t.Fatalf("writing cgroup file: %v", err)
+	}
+	if err := os.Symlink(pid, filepath.Join(root, "self")); err != nil {
+		t.Fatalf("creating self symlink: %v", err)
+	}
+
+	return root
 }
 
 // writeTempFile writes content to a uniquely-named temp file and returns its path.

--- a/internal/crocochrome/crocochrome.go
+++ b/internal/crocochrome/crocochrome.go
@@ -111,12 +111,12 @@ func (o Options) withDefaults() Options {
 		o.Registry = prometheus.NewRegistry() // Empty, unused.
 	}
 
-	if o.CgroupMemoryEventsPath == "" {
-		o.CgroupMemoryEventsPath = detectCgroupMemoryEventsPath()
-	}
-
 	if o.ProcFSRoot == "" {
 		o.ProcFSRoot = "/proc"
+	}
+
+	if o.CgroupMemoryEventsPath == "" {
+		o.CgroupMemoryEventsPath = detectCgroupMemoryEventsPath(o.ProcFSRoot)
 	}
 
 	return o

--- a/internal/crocochrome/proc.go
+++ b/internal/crocochrome/proc.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs"
 )
 
 // processInfo holds OS-level information for a single process in the Chromium process tree.
@@ -106,48 +108,32 @@ func chromiumProcessType(pid int, procRoot string) string {
 	}
 }
 
-// processMemoryStats reads /proc/<pid>/status and returns the current RSS (VmRSS) and
-// peak RSS (VmHWM) in bytes. Both fields are parsed in a single pass; no extra syscall
-// is needed. Values are in KiB in the status file; this function converts to bytes.
+// processMemoryStats returns the current RSS (VmRSS) and peak RSS (VmHWM) in bytes for
+// the given pid, parsed from /proc/<pid>/status via prometheus/procfs.
 //
 // VmHWM (high-water mark) is the peak RSS since the process started. Since Chromium
 // subprocesses are spawned fresh per session, VmHWM is effectively the session peak.
 func processMemoryStats(pid int, procRoot string) (rss, peakRSS int64, _ error) {
-	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "status"))
+	fs, err := procfs.NewFS(procRoot)
+	if err != nil {
+		return 0, 0, fmt.Errorf("opening procfs at %q: %w", procRoot, err)
+	}
+
+	p, err := fs.Proc(pid)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	for _, line := range strings.Split(string(data), "\n") {
-		switch {
-		case strings.HasPrefix(line, "VmRSS:"):
-			fields := strings.Fields(line)
-			if len(fields) < 2 {
-				return 0, 0, fmt.Errorf("unexpected VmRSS line format: %q", line)
-			}
-			kb, err := strconv.ParseInt(fields[1], 10, 64)
-			if err != nil {
-				return 0, 0, fmt.Errorf("parsing VmRSS value %q: %w", fields[1], err)
-			}
-			rss = kb * 1024
-		case strings.HasPrefix(line, "VmHWM:"):
-			fields := strings.Fields(line)
-			if len(fields) < 2 {
-				return 0, 0, fmt.Errorf("unexpected VmHWM line format: %q", line)
-			}
-			kb, err := strconv.ParseInt(fields[1], 10, 64)
-			if err != nil {
-				return 0, 0, fmt.Errorf("parsing VmHWM value %q: %w", fields[1], err)
-			}
-			peakRSS = kb * 1024
-		}
+	st, err := p.NewStatus()
+	if err != nil {
+		return 0, 0, err
 	}
 
-	if rss == 0 && peakRSS == 0 {
+	if st.VmRSS == 0 && st.VmHWM == 0 {
 		return 0, 0, fmt.Errorf("VmRSS/VmHWM not found in /proc/%d/status", pid)
 	}
 
-	return rss, peakRSS, nil
+	return int64(st.VmRSS), int64(st.VmHWM), nil
 }
 
 // collectProcessMetrics walks cgroup.procs and returns per-process info plus the total


### PR DESCRIPTION
The original implementation hand rolled a few details on how to scrape specific metrics from the file system. This is brittle and not tested at scale, and think we should instead use `prometheus/procfs` to handle this. The code is well tested, been in production environments for years, and handles all of the scenarios we're looking to handle.