### PR TITLE
feat: Support k6 v2 in integration tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,20 @@
         "ghcr.io/grafana/chromium-swiftshader-alpine"
       ],
       "versioning": "loose"
+    },
+    {
+      "matchPackageNames": [
+        "grafana/k6"
+      ],
+      "matchCurrentVersion": ">=1.0.0 <2.0.0",
+      "allowedVersions": "<2.0.0"
+    },
+    {
+      "matchPackageNames": [
+        "grafana/k6"
+      ],
+      "matchCurrentVersion": ">=2.0.0 <3.0.0",
+      "allowedVersions": "<3.0.0"
     }
   ]
 }

--- a/.github/renovate.yaml
+++ b/.github/renovate.yaml
@@ -32,3 +32,13 @@ packageRules:
     matchPackageNames:
       - ghcr.io/grafana/chromium-swiftshader-alpine
     versioning: loose
+
+  - matchPackageNames:
+      - grafana/k6
+    matchCurrentVersion: '>=1.0.0 <2.0.0'
+    allowedVersions: '<2.0.0'
+
+  - matchPackageNames:
+      - grafana/k6
+    matchCurrentVersion: '>=2.0.0 <3.0.0'
+    allowedVersions: '<3.0.0'

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -81,7 +81,7 @@ func TestIntegration(t *testing.T) {
 			Networks:   []string{network.Name},
 		},
 	})
-	testcontainers.CleanupContainer(t, cc)
+	testcontainers.CleanupContainer(t, k6)
 	if err != nil {
 		t.Fatalf("starting k6 container: %v", err)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -71,73 +71,79 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("getting crocochrome endpoint: %v", err)
 	}
 
-	// Create a k6 container to run the scripts from.
-	k6, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		Started: true,
-		ContainerRequest: testcontainers.ContainerRequest{
-			// Renovate updates the version below. Keep its format as it is or update the renovate config with it.
-			Image:      "grafana/k6:1.7.1",
-			Entrypoint: []string{"/bin/sleep", "infinity"},
-			Networks:   []string{network.Name},
-		},
-	})
-	testcontainers.CleanupContainer(t, k6)
-	if err != nil {
-		t.Fatalf("starting k6 container: %v", err)
-	}
-
-	for _, tc := range []struct {
-		name   string
-		script string
-	}{
-		{
-			name:   "simple browser test",
-			script: scriptk6io,
-		},
+	// Test crocochrome in combination with both active k6 versions, v1 and v2.
+	for _, k6Version := range []string{
+		// Renovate updates the versions below.
+		// Keep the format as it is or update the renovate config with it.
+		"grafana/k6:1.7.1",
+		"grafana/k6:2.0.0",
 	} {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			// Crocochrome can only run one session at a time. Do not run in parallel.
-			session, err := createSession(endpoint)
-			if err != nil {
-				t.Fatalf("creating session: %v", err)
-			}
-
-			t.Cleanup(func() {
-				err := deleteSession(endpoint, session.ID)
-				if err != nil {
-					t.Fatalf("deleting session: %v", err)
-				}
+		t.Run(k6Version, func(t *testing.T) {
+			k6, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+				Started: true,
+				ContainerRequest: testcontainers.ContainerRequest{
+					Image:      k6Version,
+					Entrypoint: []string{"/bin/sleep", "infinity"},
+					Networks:   []string{network.Name},
+				},
 			})
-
-			// TODO: Would be NEAT if we could just use stdin. However testcontainers does not seem to support that.
-			scriptPath := filepath.Join("/", "home", "k6", strings.ReplaceAll(t.Name(), "/", "_")+".js")
-			err = k6.CopyToContainer(ctx, []byte(tc.script), scriptPath, 0o644)
+			testcontainers.CleanupContainer(t, k6)
 			if err != nil {
-				t.Fatalf("copying k6 script to container: %v", err)
+				t.Fatalf("starting k6 container: %v", err)
 			}
 
-			rc, stdouterr, err := k6.Exec(
-				ctx,
-				[]string{"k6", "run", scriptPath},
-				exec.Multiplexed(),
-				exec.WithEnv([]string{"K6_BROWSER_WS_URL=ws://" + ccName + ":8080/proxy/" + session.ID}),
-			)
-			if err != nil {
-				t.Fatalf("running k6 script: %v", err)
-			}
+			for _, tc := range []struct {
+				name   string
+				script string
+			}{
+				{
+					name:   "simple browser test",
+					script: scriptk6io,
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					// Crocochrome can only run one session at a time. Do not run in parallel.
+					session, err := createSession(endpoint)
+					if err != nil {
+						t.Fatalf("creating session: %v", err)
+					}
 
-			output, _ := io.ReadAll(stdouterr)
-			t.Logf("k6 output:\n%s", string(output))
+					t.Cleanup(func() {
+						err := deleteSession(endpoint, session.ID)
+						if err != nil {
+							t.Fatalf("deleting session: %v", err)
+						}
+					})
 
-			// Usual k6 hack: k6 will exit with 0 even if fatal errors occur.
-			if bytes.Contains(output, []byte("error")) {
-				t.Fatalf("k6 output contains the string \"error\"")
-			}
+					// TODO: Would be NEAT if we could just use stdin. However testcontainers does not seem to support that.
+					scriptPath := filepath.Join("/", "home", "k6", strings.ReplaceAll(t.Name(), "/", "_")+".js")
+					err = k6.CopyToContainer(ctx, []byte(tc.script), scriptPath, 0o644)
+					if err != nil {
+						t.Fatalf("copying k6 script to container: %v", err)
+					}
 
-			if rc != 0 {
-				t.Fatalf("unexpected k6 return code %d", rc)
+					rc, stdouterr, err := k6.Exec(
+						ctx,
+						[]string{"k6", "run", scriptPath},
+						exec.Multiplexed(),
+						exec.WithEnv([]string{"K6_BROWSER_WS_URL=ws://" + ccName + ":8080/proxy/" + session.ID}),
+					)
+					if err != nil {
+						t.Fatalf("running k6 script: %v", err)
+					}
+
+					output, _ := io.ReadAll(stdouterr)
+					t.Logf("k6 output:\n%s", string(output))
+
+					// Usual k6 hack: k6 will exit with 0 even if fatal errors occur.
+					if bytes.Contains(output, []byte("error")) {
+						t.Fatalf("k6 output contains the string \"error\"")
+					}
+
+					if rc != 0 {
+						t.Fatalf("unexpected k6 return code %d", rc)
+					}
+				})
 			}
 		})
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -23,6 +23,13 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+const (
+	// Renovate updates the images below.
+	// Keep the format as it is or update the renovate config with it.
+	k6V1ImageVersion = "grafana/k6:1.7.1"
+	k6V2ImageVersion = "grafana/k6:2.0.0"
+)
+
 // TestIntegration performs integration tests by spinning up a production-ish container and try to run k6 against it,
 // implementing a client to crocochrome and using the official k6 image to run the test.
 func TestIntegration(t *testing.T) {
@@ -71,18 +78,19 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("getting crocochrome endpoint: %v", err)
 	}
 
-	// Test crocochrome in combination with both active k6 versions, v1 and v2.
-	for _, k6Version := range []string{
-		// Renovate updates the versions below.
-		// Keep the format as it is or update the renovate config with it.
-		"grafana/k6:1.7.1",
-		"grafana/k6:2.0.0",
+	for _, tc := range []struct {
+		name   string
+		image  string
+		script string
+	}{
+		{"k6-v1/simple browser test", k6V1ImageVersion, scriptk6io},
+		{"k6-v2/simple browser test", k6V2ImageVersion, scriptk6io},
 	} {
-		t.Run(k6Version, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			k6, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 				Started: true,
 				ContainerRequest: testcontainers.ContainerRequest{
-					Image:      k6Version,
+					Image:      tc.image,
 					Entrypoint: []string{"/bin/sleep", "infinity"},
 					Networks:   []string{network.Name},
 				},
@@ -92,58 +100,46 @@ func TestIntegration(t *testing.T) {
 				t.Fatalf("starting k6 container: %v", err)
 			}
 
-			for _, tc := range []struct {
-				name   string
-				script string
-			}{
-				{
-					name:   "simple browser test",
-					script: scriptk6io,
-				},
-			} {
-				t.Run(tc.name, func(t *testing.T) {
-					// Crocochrome can only run one session at a time. Do not run in parallel.
-					session, err := createSession(endpoint)
-					if err != nil {
-						t.Fatalf("creating session: %v", err)
-					}
+			// Crocochrome can only run one session at a time. Do not run in parallel.
+			session, err := createSession(endpoint)
+			if err != nil {
+				t.Fatalf("creating session: %v", err)
+			}
 
-					t.Cleanup(func() {
-						err := deleteSession(endpoint, session.ID)
-						if err != nil {
-							t.Fatalf("deleting session: %v", err)
-						}
-					})
+			t.Cleanup(func() {
+				err := deleteSession(endpoint, session.ID)
+				if err != nil {
+					t.Fatalf("deleting session: %v", err)
+				}
+			})
 
-					// TODO: Would be NEAT if we could just use stdin. However testcontainers does not seem to support that.
-					scriptPath := filepath.Join("/", "home", "k6", strings.ReplaceAll(t.Name(), "/", "_")+".js")
-					err = k6.CopyToContainer(ctx, []byte(tc.script), scriptPath, 0o644)
-					if err != nil {
-						t.Fatalf("copying k6 script to container: %v", err)
-					}
+			// TODO: Would be NEAT if we could just use stdin. However testcontainers does not seem to support that.
+			scriptPath := filepath.Join("/", "home", "k6", strings.ReplaceAll(t.Name(), "/", "_")+".js")
+			err = k6.CopyToContainer(ctx, []byte(tc.script), scriptPath, 0o644)
+			if err != nil {
+				t.Fatalf("copying k6 script to container: %v", err)
+			}
 
-					rc, stdouterr, err := k6.Exec(
-						ctx,
-						[]string{"k6", "run", scriptPath},
-						exec.Multiplexed(),
-						exec.WithEnv([]string{"K6_BROWSER_WS_URL=ws://" + ccName + ":8080/proxy/" + session.ID}),
-					)
-					if err != nil {
-						t.Fatalf("running k6 script: %v", err)
-					}
+			rc, stdouterr, err := k6.Exec(
+				ctx,
+				[]string{"k6", "run", scriptPath},
+				exec.Multiplexed(),
+				exec.WithEnv([]string{"K6_BROWSER_WS_URL=ws://" + ccName + ":8080/proxy/" + session.ID}),
+			)
+			if err != nil {
+				t.Fatalf("running k6 script: %v", err)
+			}
 
-					output, _ := io.ReadAll(stdouterr)
-					t.Logf("k6 output:\n%s", string(output))
+			output, _ := io.ReadAll(stdouterr)
+			t.Logf("k6 output:\n%s", string(output))
 
-					// Usual k6 hack: k6 will exit with 0 even if fatal errors occur.
-					if bytes.Contains(output, []byte("error")) {
-						t.Fatalf("k6 output contains the string \"error\"")
-					}
+			// Usual k6 hack: k6 will exit with 0 even if fatal errors occur.
+			if bytes.Contains(output, []byte("error")) {
+				t.Fatalf("k6 output contains the string \"error\"")
+			}
 
-					if rc != 0 {
-						t.Fatalf("unexpected k6 return code %d", rc)
-					}
-				})
+			if rc != 0 {
+				t.Fatalf("unexpected k6 return code %d", rc)
 			}
 		})
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -32,7 +32,7 @@ func TestIntegration(t *testing.T) {
 		t.Skipf("Skipping integration test due to -short")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	image, err := buildImage("..", "crocochrome")


### PR DESCRIPTION
Adds support for both k6 active versions, k6 v1.x and k6 v2.x, as part of integration tests.
Also updates the renovate configuration in order to keep both k6 versions up to date within their respective major versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to integration test coverage and Renovate configuration, with the main impact being potentially longer/slightly flakier CI due to running the suite against two k6 images.
> 
> **Overview**
> Integration tests now run the same k6 browser script against **both** `grafana/k6` v1 and v2 by parameterizing the k6 image and creating a per-subtest k6 container (with image versions defined as constants). The test context is also updated to use `t.Context()` for cancellation.
> 
> Renovate configuration is updated to keep the two pinned k6 image versions up to date **within their respective major versions** by adding version constraints for `grafana/k6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64691e859a7e7049b13e4bbd1078a37d83333fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->