### PR TITLE
fix: set WS proxy Host to Chromium's own host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/crocochrome
 go 1.25.0
 
 require (
+	github.com/gorilla/websocket v1.5.3
 	github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c
 	github.com/moby/moby/api v1.55.0
 	github.com/prometheus/client_golang v1.23.2
@@ -33,7 +34,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -83,20 +83,37 @@ func TestIntegration(t *testing.T) {
 		name   string
 		image  string
 		script string
+		// crocoHost is the host:port k6 uses to reach crocochrome. When it is not
+		// localhost, k6 joins the shared network by name instead of sharing
+		// crocochrome's network namespace, exercising the non-localhost Host path
+		// (regression test for https://github.com/grafana/crocochrome/issues/519).
+		crocoHost string
 	}{
-		{"k6-v1/simple browser test", k6V1ImageVersion, scriptk6io},
-		{"k6-v2/simple browser test", k6V2ImageVersion, scriptk6io},
+		{"k6-v1/simple browser test", k6V1ImageVersion, scriptk6io, "localhost:8080"},
+		{"k6-v2/simple browser test", k6V2ImageVersion, scriptk6io, "localhost:8080"},
+		{"k6-v2/non-localhost host", k6V2ImageVersion, scriptk6io, ccName + ":8080"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			localhost := tc.crocoHost == "localhost:8080"
+
+			req := testcontainers.ContainerRequest{
+				Image:      tc.image,
+				Entrypoint: []string{"/bin/sleep", "infinity"},
+			}
+			if localhost {
+				// Share crocochrome's network namespace so k6 reaches it at localhost.
+				req.HostConfigModifier = func(hc *container.HostConfig) {
+					hc.NetworkMode = container.NetworkMode("container:" + cc.GetContainerID())
+				}
+			} else {
+				// Join the shared network by name so k6 resolves crocochrome by its
+				// container name, reaching it over a non-localhost Host.
+				req.Networks = []string{network.Name}
+			}
+
 			k6, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-				Started: true,
-				ContainerRequest: testcontainers.ContainerRequest{
-					Image:      tc.image,
-					Entrypoint: []string{"/bin/sleep", "infinity"},
-					HostConfigModifier: func(hc *container.HostConfig) {
-						hc.NetworkMode = container.NetworkMode("container:" + cc.GetContainerID())
-					},
-				},
+				Started:          true,
+				ContainerRequest: req,
 			})
 			testcontainers.CleanupContainer(t, k6)
 			if err != nil {
@@ -127,7 +144,7 @@ func TestIntegration(t *testing.T) {
 				ctx,
 				[]string{"k6", "run", scriptPath},
 				exec.Multiplexed(),
-				exec.WithEnv([]string{"K6_BROWSER_WS_URL=ws://localhost:8080/proxy/" + session.ID}),
+				exec.WithEnv([]string{"K6_BROWSER_WS_URL=ws://" + tc.crocoHost + "/proxy/" + session.ID}),
 			)
 			if err != nil {
 				t.Fatalf("running k6 script: %v", err)

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -123,6 +123,17 @@ func (s *Server) Proxy(rw http.ResponseWriter, r *http.Request) {
 		Backend: func(r *http.Request) *url.URL {
 			return chromiumURL
 		},
+		// Chromium 149+ DevTools rejects any Host that is not an IP or localhost
+		// (DNS-rebinding protection). websocketproxy forwards the client's Host by
+		// default; override it with the backend's own advertised host — the address
+		// Chromium itself is listening on (loopback; 127.0.0.1:<port> on Chromium
+		// 149), which Chromium's Host check accepts by construction. Also drop any
+		// forwarded Origin, which would be rejected the same way (CDP clients don't
+		// send one).
+		Director: func(_ *http.Request, out http.Header) {
+			out.Set("Host", chromiumURL.Host)
+			out.Del("Origin")
+		},
 	}
 	wsp.ServeHTTP(rw, r)
 }

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -2,14 +2,18 @@ package http_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/gorilla/websocket"
 	"github.com/grafana/crocochrome/internal/crocochrome"
 	crocohttp "github.com/grafana/crocochrome/internal/http"
 	"github.com/grafana/crocochrome/internal/testutil"
@@ -68,4 +72,108 @@ func TestHTTP(t *testing.T) {
 			t.Fatalf("expected returned url to be replaced to /proxy, got %q", parsedURL.String())
 		}
 	})
+
+	// Regression test for https://github.com/grafana/crocochrome/issues/519.
+	// Chromium 149+ rejects a WS upgrade whose Host header is not an IP or localhost
+	// (DevTools DNS-rebinding protection). The proxy must dial Chromium with the
+	// backend's Host (127.0.0.1:<port>), not forward the client's Host.
+	t.Run("proxy dials chromium with backend Host, not the client's", func(t *testing.T) {
+		// Stand up a mock that plays Chromium: it serves /json/version (pointing the
+		// debugger URL at itself over an IP host) and a WS endpoint that mimics
+		// Chromium 149 by rejecting any non-IP, non-localhost Host.
+		var recordedHost atomic.Pointer[string]
+		upgrader := websocket.Upgrader{
+			CheckOrigin: func(*http.Request) bool { return true },
+		}
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/devtools/browser/", func(rw http.ResponseWriter, r *http.Request) {
+			host := r.Host
+			recordedHost.Store(&host)
+
+			// Mimic Chromium 149's DNS-rebinding protection.
+			if !isIPOrLocalhost(host) {
+				rw.WriteHeader(http.StatusInternalServerError)
+				_, _ = rw.Write([]byte("Host header is specified and is not an IP address or localhost."))
+				return
+			}
+
+			conn, err := upgrader.Upgrade(rw, r, nil)
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		})
+
+		var wsHost string
+		mux.HandleFunc("GET /json/version", func(rw http.ResponseWriter, _ *http.Request) {
+			_, _ = fmt.Fprintf(rw, `{"webSocketDebuggerUrl": "ws://%s/devtools/browser/abc"}`, wsHost)
+		})
+
+		chromium := httptest.NewServer(mux)
+		t.Cleanup(chromium.Close)
+		wsHost = chromium.Listener.Addr().String() // 127.0.0.1:<port>
+
+		_, port, err := net.SplitHostPort(wsHost)
+		if err != nil {
+			t.Fatalf("splitting mock chromium address: %v", err)
+		}
+
+		hb := testutil.NewHeartbeat(t)
+		cc := crocochrome.New(logger, crocochrome.Options{ChromiumPath: hb.Path, ChromiumPort: port})
+		api := crocohttp.New(logger, cc)
+
+		server := httptest.NewServer(api)
+		t.Cleanup(server.Close)
+
+		resp, err := http.Post(server.URL+"/sessions", "", nil)
+		if err != nil {
+			t.Fatalf("creating session: %v", err)
+		}
+		defer resp.Body.Close() //nolint:errcheck // We can safely ignore this error.
+
+		var session struct {
+			ID string `json:"id"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&session); err != nil {
+			t.Fatalf("decoding session: %v", err)
+		}
+		if session.ID == "" {
+			t.Fatalf("session ID is empty")
+		}
+
+		// Connect to the proxy exactly like a CDP client reaching us over a
+		// service/DNS name: a non-localhost Host and no Origin.
+		proxyURL := "ws://" + server.Listener.Addr().String() + "/proxy/" + session.ID
+		header := http.Header{}
+		header.Set("Host", "crocochrome-abc:8080")
+
+		conn, wsResp, err := websocket.DefaultDialer.Dial(proxyURL, header)
+		if err != nil {
+			status := 0
+			if wsResp != nil {
+				status = wsResp.StatusCode
+			}
+			t.Fatalf("proxy handshake failed (status %d): %v", status, err)
+		}
+		_ = conn.Close()
+
+		got := recordedHost.Load()
+		if got == nil {
+			t.Fatalf("mock chromium never received a connection")
+		}
+		if *got != wsHost {
+			t.Fatalf("chromium received Host %q, want backend host %q", *got, wsHost)
+		}
+	})
+}
+
+// isIPOrLocalhost reports whether the host part of a host[:port] string is an IP
+// address or "localhost", mirroring Chromium 149's DevTools Host check.
+func isIPOrLocalhost(hostport string) bool {
+	host := hostport
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	}
+	return host == "localhost" || net.ParseIP(host) != nil
 }


### PR DESCRIPTION
The /proxy handler reverse-proxies WebSocket traffic to Chromium via koding/websocketproxy, which forwards the incoming client's Host header to the backend dial by default. Chromium 149 added DevTools DNS-rebinding protection that rejects any Host that is not an IP address or localhost, so a client reaching crocochrome over a service/DNS name (e.g. ws://crocochrome-abc:8080/proxy/<id>) gets "websocket: bad handshake". Chromium 146 accepted such hosts, but newer version don't.

Override the outgoing Host via websocketproxy's Director so the backend dial uses Chromium's own advertised host (the address it reports it is listening on, which its Host check accepts by construction) instead of the client's. Also drop any forwarded Origin, which would be rejected the same way.

Add a unit test with a mock backend that mimics Chromium 149's Host check, and an integration test case that reaches crocochrome over a non-localhost container name. The existing tests connect via localhost, which Chromium still accepts, so they did not catch this.

Fixes #519